### PR TITLE
Massive code refactor

### DIFF
--- a/addons/sourcemod/configs/zcontracts/admin_directories.txt
+++ b/addons/sourcemod/configs/zcontracts/admin_directories.txt
@@ -1,0 +1,4 @@
+"AdminDicts"
+{
+	"root/testing"	"z"
+}

--- a/addons/sourcemod/configs/zcontracts/testing/testing_activeweapon_classname.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_activeweapon_classname.txt
@@ -7,6 +7,7 @@
 		"type"		"2"
 		"maximum_cp"	"50"
 		"active_weapon_classname"	"tf_weapon_shotgun"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_activeweapon_econname.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_activeweapon_econname.txt
@@ -7,6 +7,7 @@
 		"type"		"2"
 		"maximum_cp"	"50"
 		"active_weapon_name"		"Panic Attack Shotgun"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_activeweapon_itemdef.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_activeweapon_itemdef.txt
@@ -7,6 +7,7 @@
 		"type"		"2"
 		"maximum_cp"	"50"
 		"active_weapon_itemdef"		"1153"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_activeweapon_slot.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_activeweapon_slot.txt
@@ -7,6 +7,7 @@
 		"type"		"2"
 		"maximum_cp"	"50"
 		"active_weapon_slot"	"primary"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_basic.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_basic.txt
@@ -6,6 +6,7 @@
 		"directory"	"root/testing"
 		"type"		"2"
 		"maximum_cp"	"50"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_end_time.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_end_time.txt
@@ -6,6 +6,7 @@
 		"directory"	"root/testing"
 		"type"		"2"
 		"maximum_cp"	"50"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_invweapon_classname.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_invweapon_classname.txt
@@ -7,6 +7,7 @@
 		"type"		"2"
 		"maximum_cp"	"50"
 		"inventory_item_classname"	"tf_weapon_shotgun"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_invweapon_econname.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_invweapon_econname.txt
@@ -7,6 +7,7 @@
 		"type"		"2"
 		"maximum_cp"	"50"
 		"inventory_item_name"		"Panic Attack Shotgun"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_invweapon_itemdef.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_invweapon_itemdef.txt
@@ -7,6 +7,7 @@
 		"type"		"2"
 		"maximum_cp"	"50"
 		"inventory_item_itemdef"		"1153"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_lotsobjectives.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_lotsobjectives.txt
@@ -6,6 +6,7 @@
 		"directory"	"root/testing"
 		"type"		"2"
 		"maximum_cp"	"50"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_lotsobjectives_inf.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_lotsobjectives_inf.txt
@@ -6,6 +6,7 @@
 		"directory"	"root/testing"
 		"type"		"2"
 		"maximum_cp"	"50"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_reset.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_reset.txt
@@ -6,6 +6,7 @@
 		"directory"	"root/testing"
 		"type"		"2"
 		"maximum_cp"	"50"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_start_and_end_time.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_start_and_end_time.txt
@@ -6,6 +6,7 @@
 		"directory"	"root/testing"
 		"type"		"2"
 		"maximum_cp"	"50"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_start_time.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_start_time.txt
@@ -6,6 +6,7 @@
 		"directory"	"root/testing"
 		"type"		"2"
 		"maximum_cp"	"50"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_subtract.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_subtract.txt
@@ -6,6 +6,7 @@
 		"directory"	"root/testing"
 		"type"		"2"
 		"maximum_cp"	"50"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_teams_blue.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_teams_blue.txt
@@ -6,6 +6,7 @@
 		"directory"	"root/testing"
 		"type"		"2"
 		"maximum_cp"	"50"
+		"required_flag"	"z"
 
 		"team_restriction"	"blue"
 

--- a/addons/sourcemod/configs/zcontracts/testing/testing_teams_red.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_teams_red.txt
@@ -6,6 +6,7 @@
 		"directory"	"root/testing"
 		"type"		"2"
 		"maximum_cp"	"50"
+		"required_flag"	"z"
 
 		"team_restriction"	"red"
 

--- a/addons/sourcemod/configs/zcontracts/testing/testing_timers.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_timers.txt
@@ -6,6 +6,7 @@
 		"directory"	"root/testing"
 		"type"		"2"
 		"maximum_cp"	"50"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_timers_add.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_timers_add.txt
@@ -6,6 +6,7 @@
 		"directory"	"root/testing"
 		"type"		"2"
 		"maximum_cp"	"50"
+		"required_flag"	"z"
 
 		// What classes can do this contract?
 		"classes"

--- a/addons/sourcemod/configs/zcontracts/testing/testing_timers_add.txt
+++ b/addons/sourcemod/configs/zcontracts/testing/testing_timers_add.txt
@@ -25,7 +25,8 @@
 		{
 			"1"
 			{
-				"description"		"Kill three players within 10 seconds."
+				"description"		"Kill five players within 10 seconds."
+				"extended_description"	"Kill five players within 10 seconds.#Getting a kill with the timer active will add an additional three seconds."
 				"infinite"			"1"
 				
 				// How many points should we give for successfully doing this objective?
@@ -40,7 +41,7 @@
 						"type"		"increment"
 						
 						// How many times does this event need to trigger to add points?
-						"threshold"	"3"
+						"threshold"	"5"
 
 						"timer"
 						{

--- a/addons/sourcemod/scripting/include/zcontracts/zcontracts.inc
+++ b/addons/sourcemod/scripting/include/zcontracts/zcontracts.inc
@@ -64,13 +64,49 @@ enum ContractType
 // Examples: "pl_upward", "ctf_2fort", "koth_", "pl_constantlyupdated_v3"
 //
 // Team restriction: "team_restriction". This can be a team index number or a special name.
+
+// Definitions for things that are used in the base ZContracts plugin:
+
+#define CONTRACT_DEF_NAME "name"
+#define CONTRACT_DEF_DIRECTORY "directory"
+#define CONTRACT_DEF_TYPE "type"
+#define CONTRACT_DEF_MAX_PROGRESS "maximum_cp"
+#define CONTRACT_DEF_OBJECTIVES "objectives"
+#define CONTRACT_DEF_REQUIRED "required_contracts"
+#define CONTRACT_DEF_DIFFICULTY "difficulty"
+
+#define CONTRACT_DEF_OBJ_DESC "description"
+#define CONTRACT_DEF_OBJ_EXT_DESC "extended_description"
+#define CONTRACT_DEF_OBJ_INFINITE "infinite"
+#define CONTRACT_DEF_OBJ_AWARD "award"
+#define CONTRACT_DEF_OBJ_EVENTS "events"
+#define CONTRACT_DEF_OBJ_MAX_PROGRESS "maximum_cp"
+#define CONTRACT_DEF_OBJ_NO_MULTI "no_multiplication"
+
+#define CONTRACT_DEF_EVENT_TYPE "type"
+#define CONTRACT_DEF_EVENT_THRESHOLD "threshold"
+#define CONTRACT_DEF_EVENT_TIMER "timer"
+#define CONTRACT_DEF_TIMER_TIME "time"
+
+#define CONTRACT_DEF_ACTIVE_WEAPON_SLOT	"active_weapon_slot"
+#define CONTRACT_DEF_ACTIVE_WEAPON_NAME	"active_weapon_name"
+#define CONTRACT_DEF_ACTIVE_WEAPON_CLASSNAME "active_weapon_classname"
+#define CONTRACT_DEF_ACTIVE_WEAPON_ITEMDEF "active_weapon_itemdef"
+
+#define CONTRACT_DEF_INV_ITEM_NAME "inventory_item_name"
+#define CONTRACT_DEF_INV_ITEM_CLASSNAME "inventory_item_classname"
+#define CONTRACT_DEF_INV_ITEM_ITEMDEF "inventory_item_itemdef"
+
+#define CONTRACT_DEF_MAP "map_restriction"
+#define CONTRACT_DEF_TEAM "team_restriction"
+
+#define CONTRACT_DEF_UNIX_START "contract_start_unixtime"
+#define CONTRACT_DEF_UNIX_END "contract_end_unixtime"
+
 enum struct Contract
 {
 	bool Initalized;
 	bool Active;
-
-	KeyValues CachedSchema;
-	ArrayList CachedObjSchema;
 
 	// Internal representation of the Contract.
 	char UUID[MAX_UUID_SIZE];
@@ -115,20 +151,21 @@ enum struct Contract
 	{
 		if (!this.Active || !this.Initalized) return false;
 		
-		switch (view_as<ContractType>(this.CachedSchema.GetNum("type")))
+		switch (view_as<ContractType>(this.GetSchema().GetNum(CONTRACT_DEF_TYPE)))
 		{
 			case Contract_ObjectiveProgress: // All objectives must be complete.
 			{
 				for (int i = 0; i < this.ObjectiveCount; i++)
 				{
-					KeyValues ObjSchema = this.CachedObjSchema.Get(i);
-					return (this.ObjectiveProgress.Get(i) >= ObjSchema.GetNum("maximum_cp"));
+					KeyValues ObjSchema = this.GetObjectiveSchema(i);
+					if (ObjSchema.GetNum(CONTRACT_DEF_OBJ_INFINITE) == 1) continue;
+					if (!this.IsObjectiveComplete(i)) return false;
 				}
 				return true;
 			}
 			case Contract_ContractProgress: // The Contract's progress bar must be complete.
 			{
-				return this.ContractProgress >= this.CachedSchema.GetNum("maximum_cp");
+				return this.ContractProgress >= this.GetSchema().GetNum(CONTRACT_DEF_MAX_PROGRESS);
 			}	
 		}
 		return false;
@@ -136,19 +173,30 @@ enum struct Contract
 
 	bool IsObjectiveComplete(int ObjectiveID)
 	{
-		KeyValues ObjSchema = this.CachedObjSchema.Get(ObjectiveID);
-		return (this.ObjectiveProgress.Get(ObjectiveID) >= ObjSchema.GetNum("maximum_cp"));
+		KeyValues ObjSchema = this.GetObjectiveSchema(ObjectiveID);
+		if (ObjSchema.GetNum(CONTRACT_DEF_OBJ_INFINITE) == 1) return false;
+		return (this.ObjectiveProgress.Get(ObjectiveID) >= ObjSchema.GetNum(CONTRACT_DEF_OBJ_MAX_PROGRESS));
 	}
 
 	bool IsObjectiveInfinite(int ObjectiveID)
 	{
-		KeyValues ObjSchema = this.CachedObjSchema.Get(ObjectiveID);
-		return (ObjSchema.GetNum("infinite") == 1)
+		KeyValues ObjSchema = this.GetObjectiveSchema(ObjectiveID);
+		return (ObjSchema.GetNum(CONTRACT_DEF_OBJ_INFINITE) == 1)
 	}
 
 	bool IsTimerRunning(int ObjectiveID)
 	{
 		return (this.ObjectiveTimers.Get(ObjectiveID) != INVALID_HANDLE);
+	}
+
+	KeyValues GetSchema()
+	{
+		return GetContractSchema(this.UUID);
+	}
+
+	KeyValues GetObjectiveSchema(int ObjectiveID)
+	{
+		return GetObjectiveSchema(this.UUID, ObjectiveID);
 	}
 
 	/**
@@ -161,35 +209,30 @@ enum struct Contract
 		this.ContractProgress = 0;
 		this.UUID = UUID;
 
-		this.CachedSchema = GetContractSchema(this.UUID);
 		this.ObjectiveProgress = new ArrayList();
 		this.ObjectiveThreshold = new ArrayList(sizeof(StringMap));
 		this.ObjectiveTimers = new ArrayList(sizeof(Handle));
 
-		this.CachedObjSchema = new ArrayList(sizeof(KeyValues));
-
+		KeyValues Schema = this.GetSchema()
 		// Grab the schema KeyValue objects of our objectives and store them locally.
-		if (this.CachedSchema.JumpToKey("objectives"))
+		if (Schema.JumpToKey(CONTRACT_DEF_OBJECTIVES))
 		{
 			int ObjectiveID = 0;
-			this.CachedSchema.GotoFirstSubKey();
+			Schema.GotoFirstSubKey();
 			do
 			{
-				KeyValues ObjSchema = GetObjectiveSchema(this.UUID, ObjectiveID);
-				this.CachedObjSchema.Push(ObjSchema);
 				this.ObjectiveProgress.Push(0);
 				this.ObjectiveThreshold.Push(new StringMap());
 				this.ObjectiveTimers.Push(INVALID_HANDLE);
 				this.ObjectiveCount++;
 				ObjectiveID++;
 
-			} while (this.CachedSchema.GotoNextKey());
+			} while (Schema.GotoNextKey());
 		}
 		else
 		{
 			ThrowError("Tried to load Contract with no objectives! UUID: %s", this.UUID);
 		}
-
 		this.m_bLoadedFromDatabase = false;
 		this.m_bHUD_ContractUpdate = false;
 		this.m_iHUD_ObjectiveUpdate = -1;
@@ -202,9 +245,6 @@ enum struct Contract
 	{
 		this.Initalized = false;
 		this.Active = false;
-
-		this.CachedSchema = null;
-		delete this.CachedObjSchema;
 
 		delete this.ObjectiveProgress;
 		delete this.ObjectiveThreshold;

--- a/addons/sourcemod/scripting/include/zcontracts/zcontracts.inc
+++ b/addons/sourcemod/scripting/include/zcontracts/zcontracts.inc
@@ -118,6 +118,7 @@ enum struct Contract
 	ArrayList ObjectiveProgress;
 	ArrayList ObjectiveThreshold;
 	ArrayList ObjectiveTimers;
+	ArrayList ObjectiveTimerStarted;
 	int ObjectiveCount;
 
 	// Because of the combine-event logic, there is a chance that the value passed
@@ -212,6 +213,7 @@ enum struct Contract
 		this.ObjectiveProgress = new ArrayList();
 		this.ObjectiveThreshold = new ArrayList(sizeof(StringMap));
 		this.ObjectiveTimers = new ArrayList(sizeof(Handle));
+		this.ObjectiveTimerStarted = new ArrayList();
 
 		KeyValues Schema = this.GetSchema()
 		// Grab the schema KeyValue objects of our objectives and store them locally.
@@ -224,6 +226,7 @@ enum struct Contract
 				this.ObjectiveProgress.Push(0);
 				this.ObjectiveThreshold.Push(new StringMap());
 				this.ObjectiveTimers.Push(INVALID_HANDLE);
+				this.ObjectiveTimerStarted.Push(-1.0);
 				this.ObjectiveCount++;
 				ObjectiveID++;
 
@@ -248,6 +251,8 @@ enum struct Contract
 
 		delete this.ObjectiveProgress;
 		delete this.ObjectiveThreshold;
+		delete this.ObjectiveTimers;
+		delete this.ObjectiveTimerStarted;
 		this.ObjectiveCount = 0;
 		this.ContractProgress = 0;
 

--- a/addons/sourcemod/scripting/include/zcontracts/zcontracts.inc
+++ b/addons/sourcemod/scripting/include/zcontracts/zcontracts.inc
@@ -74,6 +74,7 @@ enum ContractType
 #define CONTRACT_DEF_OBJECTIVES "objectives"
 #define CONTRACT_DEF_REQUIRED "required_contracts"
 #define CONTRACT_DEF_DIFFICULTY "difficulty"
+#define CONTRACT_DEF_REQUIRED_FLAG "required_flag"
 
 #define CONTRACT_DEF_OBJ_DESC "description"
 #define CONTRACT_DEF_OBJ_EXT_DESC "extended_description"

--- a/addons/sourcemod/scripting/include/zcontracts/zcontracts.inc
+++ b/addons/sourcemod/scripting/include/zcontracts/zcontracts.inc
@@ -69,121 +69,40 @@ enum struct ContractObjectiveEvent
 	float m_fStarted;
 	int m_iCurrentLoops;
 	
-	bool m_bInitalized;
+	bool Initalized;
 	
 	void Initalize()
 	{
-		this.m_bInitalized = true;
+		this.Initalized = true;
 	}
 	
 	void Destroy()
 	{
-		if (!this.m_bInitalized) return;
-		this.m_bInitalized = false;
-	}
-}
-
-// Contract objectives.
-enum struct ContractObjective
-{
-	// Store the original type of Contract.
-	ContractType m_iContractType;
-
-	int m_iInternalID;
-	bool m_bInitalized;
-	bool m_bInfinite;	// Objective doesn't have a maximum progress.
-	
-	char m_sDescription[MAX_OBJECTIVE_DESC_SIZE];
-	
-	// Award to give when this event is triggered.
-	int m_iAward;
-
-	// Because of the combine-event logic, there is a chance that the value passed
-	// to ProcessLogicForContractObjective() may be over the threshold. By default,
-	// the award is multiplied by the value to make up for this combination.
-	// (e.g 3 kills for 1 CP awards 3CP). Some objectives may wish to not use
-	// the multiplication (e.g heal a player for 300HP gives 5CP *only*)
-	bool m_bNoMultiplication;
-
-	// Progress of this objective. This includes how many times it should be used.
-	int m_iMaxProgress;
-	int m_iProgress;
-
-	// If the Objective progress needs to be updated in the database. This is only used
-	// with the repeating timer.
-	bool m_bNeedsDBSave;
-	
-	// Events for this Contract (see ContractObjectiveEvent).
-	ArrayList m_hEvents;
-
-	/**
-	 * @return		If this Contract is complete.
-	**/
-	bool IsObjectiveComplete()
-	{
-		if (this.m_bInfinite) return false;
-		return this.m_iProgress >= this.m_iMaxProgress;
-	}
-	/**
-	 * Creates the ArrayList for Objective Events.
-	**/
-	void Initalize()
-	{
-		this.m_hEvents = new ArrayList(sizeof(ContractObjectiveEvent));
-		this.m_bInitalized = true;
-		this.m_bNeedsDBSave = false;
-	}
-	
-	/**
-	 * Destory the ArrayList for Objective Events.
-	**/
-	void Destroy()
-	{
-		if (!this.m_bInitalized || !this.m_hEvents) return;
-		
-		// Destroy all of our events.
-		for (int i = 0; i < this.m_hEvents.Length; i++)
-		{
-			ContractObjectiveEvent hEvent;
-			this.m_hEvents.GetArray(i, hEvent, sizeof(ContractObjectiveEvent));
-			hEvent.Destroy();
-		}
-		
-		delete this.m_hEvents;
-		this.m_bInitalized = false;
-		this.m_bNeedsDBSave = false;
+		if (!this.Initalized) return;
+		this.Initalized = false;
 	}
 }
 
 // Struct representing a Contract.
 enum struct Contract
 {
-	bool m_bInitalized;
-	bool m_bActive;
+	bool Initalized;
+	bool Active;
+
+	KeyValues CachedSchema;
+	ArrayList CachedObjSchema;
 
 	// Internal representation of the Contract.
-	char m_sUUID[MAX_UUID_SIZE];
-
-	// Display name of the Contract.
-	char m_sContractName[MAX_CONTRACT_NAME_SIZE];
-	
-	// Path of where this Contract should be stored in the global Contracker.
-	char m_sDirectoryPath[MAX_DIRECTORY_SIZE]; 
-
-	// Difficulty of the Contract.
-	int m_iDifficulty;
-	
-	// The contracts the client must have completed before
-	// being allowed to activate this Contract.
-	ArrayList m_hRequiredContracts;
-
-	// What type of Contract are we handling? (see ContractType)
-	ContractType m_iContractType;
+	char UUID[MAX_UUID_SIZE];
 
 	// If we're using "contract progress" mode, there is one central
 	// progress bar that is updated alongside our objective.
-	int m_iProgress;
-	int m_iMaxProgress;
+	int ContractProgress;
+	// NOTE: values are never removed from these ArrayLists. The values are only modified.
+	ArrayList ObjectiveProgress;
+	ArrayList ObjectiveThreshold;
+	ArrayList ObjectiveTimers;
+	int ObjectiveCount;
 
 	// Because of the combine-event logic, there is a chance that the value passed
 	// to ProcessLogicForContractObjective() may be over the threshold. By default,
@@ -199,9 +118,6 @@ enum struct Contract
 	// Has this enum struct had information set from the database?
 	bool m_bLoadedFromDatabase;
 
-	// The objectives for this Contract.
-	ArrayList m_hObjectives;
-
 	// These three variables trigger visuals on the HUD.
 	bool m_bHUD_ContractUpdate;
 	int m_iHUD_ObjectiveUpdate;
@@ -209,7 +125,7 @@ enum struct Contract
 	
 	bool IsContractInitalized()
 	{
-		return this.m_sUUID[0] == '{';
+		return this.UUID[0] == '{' && this.Initalized;
 	}
 
 	/**
@@ -217,58 +133,80 @@ enum struct Contract
 	**/
 	bool IsContractComplete()
 	{
-		if (!this.m_bActive || !this.m_bInitalized) return false;
+		if (!this.Active || !this.Initalized) return false;
 		
 		switch (this.m_iContractType)
 		{
 			case Contract_ObjectiveProgress: // All objectives must be complete.
 			{
-				for (int i = 0; i < this.m_hObjectives.Length; i++)
+				for (int i = 0; i < this.m_hObjectiveProgress.Length; i++)
 				{
-					ContractObjective hContractObjective;
-					this.m_hObjectives.GetArray(i, hContractObjective);
-					if (!hContractObjective.m_bInitalized) continue;
-					if (hContractObjective.m_bInfinite) continue;
-					if (!hContractObjective.IsObjectiveComplete()) return false;
+					return (this.m_hObjectiveProgress.Get(i) >= this.CachedObjSchema.Get(i).GetNum("maximum_cp"));
 				}
 				return true;
 			}
 			case Contract_ContractProgress: // The Contract's progress bar must be complete.
 			{
-				return this.m_iProgress >= this.m_iMaxProgress;
-			}
-				
+				return this.Progress >= this.CachedSchema.GetNum("maximum_cp");
+			}	
 		}
-		
 		return false;
 	}
 
-	/**
-	 * Wrapper to easily get a Contract objective.
-	**/
-	void GetObjective(int index, ContractObjective hBuffer)
+	bool IsObjectiveComplete(int ObjectiveID)
 	{
-		this.m_hObjectives.GetArray(index, hBuffer, sizeof(ContractObjective));
+		return (this.ObjectiveProgress.Get(ObjectiveID) >= this.CachedObjSchema.Get(ObjectiveID).GetNum("maximum_cp"));
 	}
 
-	/**
-	 * Wrapper to easily save a Contract objective.
-	**/
-	void SaveObjective(int index, ContractObjective hBuffer)
+	bool IsObjectiveInfinite(int ObjectiveID)
 	{
-		this.m_hObjectives.SetArray(index, hBuffer, sizeof(ContractObjective));
+		return (this.CachedObjSchema.Get(ObjectiveID).GetNum("infinite") == 1)
+	}
+
+	bool IsTimerRunning(int ObjectiveID)
+	{
+		return (this.ObjectiveTimers.Get(ObjectiveID) != INVALID_HANDLE);
 	}
 
 	/**
 	 * Creates the ArrayList for objectives.
 	**/
-	void Initalize()
+	void Initalize(char UUID[MAX_UUID_SIZE])
 	{
-		this.m_hRequiredContracts = new ArrayList();
-		this.m_hObjectives = new ArrayList(sizeof(ContractObjective));
-		this.m_iProgress = 0;
-		this.m_bInitalized = true;
-		this.m_bActive = true;
+		this.Initalized = true;
+		this.Active = true;
+		this.Progress = 0;
+		this.UUID = UUID;
+
+		this.CachedSchema = GetContractSchema(this.UUID);
+		this.ObjectiveProgress = new ArrayList();
+		this.ObjectiveThreshold = new ArrayList(sizeof(StringMap));
+		this.ObjectiveTimers = new ArrayList(sizeof(Handle));
+
+		this.CachedObjSchema = new ArrayList(sizeof(KeyValues));
+
+		// Grab the schema KeyValue objects of our objectives and store them locally.
+		if (this.CachedSchema.JumpToKey("objectives"))
+		{
+			int ObjectiveID = 0;
+			this.CachedSchema.GotoFirstSubKey();
+			do
+			{
+				KeyValues ObjSchema = GetObjectiveSchema(ObjectiveID, this.UUID);
+				this.CachedObjSchema.Push(ObjSchema);
+				this.ObjectiveProgress.Push(0);
+				this.ObjectiveThreshold.Push(new StringMap());
+				this.ObjectiveTimers.Push(INVALID_HANDLE);
+				this.ObjectiveCount++;
+				ObjectiveID++;
+
+			} while (this.CachedSchema.GotoNextKey());
+		}
+		else
+		{
+			ThrowError("Tried to load Contract with no objectives! UUID: %s", this.UUID);
+		}
+
 		this.m_bLoadedFromDatabase = false;
 		this.m_bHUD_ContractUpdate = false;
 		this.m_iHUD_ObjectiveUpdate = -1;
@@ -279,18 +217,20 @@ enum struct Contract
 	**/
 	void Destroy()
 	{
-		for (int i = 0; i < this.m_hObjectives.Length; i++)
-		{
-			ContractObjective hContractObjective;
-			this.m_hObjectives.GetArray(i, hContractObjective);
-			if (!hContractObjective.m_bInitalized) continue;
-			hContractObjective.Destroy();
-			this.m_hObjectives.SetArray(i, hContractObjective);
-		}
-		this.m_hObjectives.Clear();
-		this.m_bInitalized = false;
-		this.m_bActive = false;
+		this.Initalized = false;
+		this.Active = false;
+
+		this.CachedSchema = null;
+		delete this.CachedObjSchema;
+
+		delete this.ObjectiveProgress;
+		delete this.ObjectiveThreshold;
+		this.ObjectiveCount = 0;
+
 		this.m_bLoadedFromDatabase = false;
+		this.m_bHUD_ContractUpdate = false;
+		this.m_iHUD_ObjectiveUpdate = -1;
+		this.m_iHUD_UpdateValue = 0;
 	}
 }
 
@@ -300,7 +240,7 @@ enum struct ObjectiveUpdate
 	int m_iValue;
 	int m_iObjectiveID;
 	char m_sEvent[MAX_EVENT_SIZE];
-	char m_sUUID[MAX_UUID_SIZE];
+	char UUID[MAX_UUID_SIZE];
 }
 
 enum struct CompletedContractInfo

--- a/addons/sourcemod/scripting/include/zcontracts/zcontracts.inc
+++ b/addons/sourcemod/scripting/include/zcontracts/zcontracts.inc
@@ -4,13 +4,13 @@
 
 #define __zcontracts_included
 
-#define ZCONTRACTS_PLUGIN_VERSION "0.10.2"
+#define ZCONTRACTS_PLUGIN_VERSION "0.11.0"
 // This value should be incremented with every breaking version made to the
 // database so saves can be easily converted. For developers who fork this project and
 // wish to merge changes, do not increment this number until merge.
 // Other plugins should use the GetContrackerVersion() native to get this value, but
 // this main plugin and subplugins are free to use the define name in its place.
-#define CONTRACKER_VERSION 2
+#define CONTRACKER_VERSION 3
 // How often the HUD will refresh itself.
 #define HUD_REFRESH_RATE 0.5
 
@@ -43,47 +43,27 @@ enum ContractType
 	Contract_ContractProgress = 2
 }
 
-// Contract objective events.
-enum struct ContractObjectiveEvent
-{
-	int m_iInternalID;
-	char m_sEventName[MAX_EVENT_SIZE];
-	
-	// If this event gets triggered and is apart of a special condition, trigger some different text.
-	char m_sExclusiveDescription[MAX_OBJECTIVE_DESC_SIZE];
-
-	// Threshold for how many times this event should called before giving an award.
-	int m_iThreshold;
-	int m_iCurrentThreshold;
-
-	char m_sEventType[16];
-	
-	// Timer logic.
-	Handle m_hTimer;
-
-	// The starting time for the timer.
-	float m_fTime; 
-	// The maximum amount of timer loops.
-	int m_iMaxLoops; 
-	// When this loop of the timer was started.
-	float m_fStarted;
-	int m_iCurrentLoops;
-	
-	bool Initalized;
-	
-	void Initalize()
-	{
-		this.Initalized = true;
-	}
-	
-	void Destroy()
-	{
-		if (!this.Initalized) return;
-		this.Initalized = false;
-	}
-}
-
 // Struct representing a Contract.
+// THERE ARE SEVERAL THINGS LISTED HERE THAT ARE NOT STORED IN THE CONTRACT STRUCT!
+// Weapon restriction types:
+// "name": Name of the Contract, duh.
+// "description": A description on how to complete the Contract or Objective.
+// "active_weapon_slot": The slot for the weapon set at m_hActiveWeapon (see items_game.txt)
+// "active_weapon_name": The display economy name for the weapon set at m_hActiveWeapon.
+// "active_weapon_classname": The classname of the weapon set at m_hActiveWeapon.
+// "active_weapon_itemdef": The item definition index for the weapon set at m_hActiveWeapon.
+// "inventory_item_name": The display economy name for an item in the players current inventory.
+// "inventory_item_classname": The classname for an item in the players current inventory.
+// "inventory_item_itemdef": The item definition index for an item in the players current inventory.
+// If a player kills another player without using the specified active weapon, the contract is not updated.
+// If a player kills another player with a specified active weapon, the contract is updated.
+// If a player kills another player without having a specified inventory item equipped, the contract is not updated.
+// If a player kills another player while having a specified inventory item equipped, the contract is updated.
+//
+// Map restriction: "map_restriction". This can be a whole map or part of a map name.
+// Examples: "pl_upward", "ctf_2fort", "koth_", "pl_constantlyupdated_v3"
+//
+// Team restriction: "team_restriction". This can be a team index number or a special name.
 enum struct Contract
 {
 	bool Initalized;
@@ -135,19 +115,20 @@ enum struct Contract
 	{
 		if (!this.Active || !this.Initalized) return false;
 		
-		switch (this.m_iContractType)
+		switch (view_as<ContractType>(this.CachedSchema.GetNum("type")))
 		{
 			case Contract_ObjectiveProgress: // All objectives must be complete.
 			{
-				for (int i = 0; i < this.m_hObjectiveProgress.Length; i++)
+				for (int i = 0; i < this.ObjectiveCount; i++)
 				{
-					return (this.m_hObjectiveProgress.Get(i) >= this.CachedObjSchema.Get(i).GetNum("maximum_cp"));
+					KeyValues ObjSchema = this.CachedObjSchema.Get(i);
+					return (this.ObjectiveProgress.Get(i) >= ObjSchema.GetNum("maximum_cp"));
 				}
 				return true;
 			}
 			case Contract_ContractProgress: // The Contract's progress bar must be complete.
 			{
-				return this.Progress >= this.CachedSchema.GetNum("maximum_cp");
+				return this.ContractProgress >= this.CachedSchema.GetNum("maximum_cp");
 			}	
 		}
 		return false;
@@ -155,12 +136,14 @@ enum struct Contract
 
 	bool IsObjectiveComplete(int ObjectiveID)
 	{
-		return (this.ObjectiveProgress.Get(ObjectiveID) >= this.CachedObjSchema.Get(ObjectiveID).GetNum("maximum_cp"));
+		KeyValues ObjSchema = this.CachedObjSchema.Get(ObjectiveID);
+		return (this.ObjectiveProgress.Get(ObjectiveID) >= ObjSchema.GetNum("maximum_cp"));
 	}
 
 	bool IsObjectiveInfinite(int ObjectiveID)
 	{
-		return (this.CachedObjSchema.Get(ObjectiveID).GetNum("infinite") == 1)
+		KeyValues ObjSchema = this.CachedObjSchema.Get(ObjectiveID);
+		return (ObjSchema.GetNum("infinite") == 1)
 	}
 
 	bool IsTimerRunning(int ObjectiveID)
@@ -175,7 +158,7 @@ enum struct Contract
 	{
 		this.Initalized = true;
 		this.Active = true;
-		this.Progress = 0;
+		this.ContractProgress = 0;
 		this.UUID = UUID;
 
 		this.CachedSchema = GetContractSchema(this.UUID);
@@ -192,7 +175,7 @@ enum struct Contract
 			this.CachedSchema.GotoFirstSubKey();
 			do
 			{
-				KeyValues ObjSchema = GetObjectiveSchema(ObjectiveID, this.UUID);
+				KeyValues ObjSchema = GetObjectiveSchema(this.UUID, ObjectiveID);
 				this.CachedObjSchema.Push(ObjSchema);
 				this.ObjectiveProgress.Push(0);
 				this.ObjectiveThreshold.Push(new StringMap());
@@ -226,6 +209,7 @@ enum struct Contract
 		delete this.ObjectiveProgress;
 		delete this.ObjectiveThreshold;
 		this.ObjectiveCount = 0;
+		this.ContractProgress = 0;
 
 		this.m_bLoadedFromDatabase = false;
 		this.m_bHUD_ContractUpdate = false;
@@ -240,7 +224,7 @@ enum struct ObjectiveUpdate
 	int m_iValue;
 	int m_iObjectiveID;
 	char m_sEvent[MAX_EVENT_SIZE];
-	char UUID[MAX_UUID_SIZE];
+	char m_sUUID[MAX_UUID_SIZE];
 }
 
 enum struct CompletedContractInfo

--- a/addons/sourcemod/scripting/include/zcontracts/zcontracts_tf2.inc
+++ b/addons/sourcemod/scripting/include/zcontracts/zcontracts_tf2.inc
@@ -7,6 +7,8 @@
 #include <tf2>
 #include <tf2_stocks>
 
+#define CONTRACT_DEF_TF2_CLASSES "classes"
+
 // ============================= SCHEMA FUNCTIONS =============================
 
 stock int TF2_GetTeamIndexFromString(const char[] team)

--- a/addons/sourcemod/scripting/zcontracts/contracts_database.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_database.sp
@@ -283,14 +283,14 @@ public any Native_SaveActiveObjectiveToDatabase(Handle plugin, int numParams)
     }
 
     int objective = GetNativeCell(2);
-    if (objective > /*zero indexed*/ GetContractObjectiveCount(UUID)-1)
+    if (objective > GetContractObjectiveCount(UUID))
     {
         LogMessage("SaveActiveObjectiveToDatabase: Invalid contract objective ID passed (%N: %d)", client, objective);
         return false;
     }
 
     // Don't save infinite objectives.
-    KeyValues Schema = GetObjectiveSchema(UUID, objective+1);
+    KeyValues Schema = GetObjectiveSchema(UUID, objective);
     if (view_as<bool>(Schema.GetNum(CONTRACT_DEF_OBJ_INFINITE, 0)))
     {
         return false;

--- a/addons/sourcemod/scripting/zcontracts/contracts_database.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_database.sp
@@ -41,16 +41,6 @@ public Action ReloadDatabase(int client, int args)
 }
 
 /**
- * The ConVar "zc_database_update_time" controls how often we update the database
- * with all of the player Contract information.
-*/
-public void OnDatabaseUpdateChange(ConVar convar, char[] oldValue, char[] newValue)
-{
-    delete g_DatabaseUpdateTimer;
-    g_DatabaseUpdateTimer = CreateTimer(StringToFloat(newValue), Timer_SaveAllToDB, _, TIMER_REPEAT);
-}
-
-/**
  * The ConVar "zc_database_retry_time" is used when an attempt to connect to the database
  * fails and we need to reattempt at a later point.
  */
@@ -63,48 +53,6 @@ public void OnDatabaseRetryChange(ConVar convar, char[] oldValue, char[] newValu
 public Action Timer_RetryDBConnect(Handle hTimer)
 {
     Database.Connect(GotDatabase, "zcontracts");
-    return Plugin_Continue;
-}
-
-/**
- * The ConVar "zc_database_update_time" controls how often we update the database
- * with all of the player Contract information.
- */
-
-// TODO: Can we make this into a transaction?
-public Action Timer_SaveAllToDB(Handle hTimer)
-{
-    for (int i = 0; i < MAXPLAYERS+1; i++)
-    {
-        if (!IsClientValid(i) || IsFakeClient(i)) continue;
-
-        // Save this contract to the database.
-        if (!ActiveContract[i].IsContractInitalized()) continue;
-
-        if (g_DB != null)
-        {
-            // Save the Contract.
-            if (ActiveContract[i].m_bNeedsDBSave)
-            {
-                SaveActiveContractToDatabase(i);
-                ActiveContract[i].m_bNeedsDBSave = false;
-            }
-            // Save each of our objectives.
-            for (int j = 0; j < ActiveContract[i].m_hObjectives.Length; j++)
-            {
-                ContractObjective ActiveContractObjective;
-                ActiveContract[i].GetObjective(j, ActiveContractObjective);
-                if (!ActiveContractObjective.m_bInitalized) continue;
-
-                if (ActiveContractObjective.m_bNeedsDBSave)
-                {
-                    SaveActiveObjectiveToDatabase(i, j);
-                    ActiveContractObjective.m_bNeedsDBSave = false;
-                    ActiveContract[i].SaveObjective(j, ActiveContractObjective);
-                }
-            }
-        }
-    }
     return Plugin_Continue;
 }
 
@@ -398,18 +346,18 @@ public void CB_SetClientContract_Contract(Database db, DBResultSet results, cons
             ThrowError("Outdated contract data. Minimum version: %d, data version: %d", MinimumRequiredVersion, DataVersion);
         }
 
-        ActiveContract[client].m_iProgress = results.FetchInt(2);
+        ActiveContract[client].ContractProgress = results.FetchInt(2);
 
         Call_StartForward(g_fOnContractProgressReceived);
         Call_PushCell(client);
-        Call_PushString(ActiveContract[client].m_sUUID);
-        Call_PushCell(ActiveContract[client].m_iProgress);
+        Call_PushString(ActiveContract[client].UUID);
+        Call_PushCell(ActiveContract[client].ContractProgress);
         Call_Finish();
 
         if (g_DebugQuery.BoolValue && IsClientValid(client))
         {
-            LogMessage("[ZContracts] %N LOAD: Successfully grabbed Contract progress from database (%d/%d).",
-            client, ActiveContract[client].m_iProgress, ActiveContract[client].m_iMaxProgress);
+            LogMessage("[ZContracts] %N LOAD: Successfully grabbed Contract progress from database. Value: %d",
+            client, ActiveContract[client].ContractProgress);
         }
     }
 
@@ -439,23 +387,20 @@ public void CB_SetClientContract_Objective(Database db, DBResultSet results, con
             ThrowError("Outdated contract objective data. Minimum version: %d, data version: %d", MinimumRequiredVersion, DataVersion);
         }
 
-        ContractObjective hObj;
         int db_id = results.FetchInt(2);
-        ActiveContract[client].GetObjective(db_id, hObj);
-        hObj.m_iProgress = results.FetchInt(3);
-        ActiveContract[client].SaveObjective(db_id, hObj);
+        ActiveContract[client].ObjectiveProgress.Set(db_id, results.FetchInt(3));
 
         Call_StartForward(g_fOnObjectiveProgressReceived);
         Call_PushCell(client);
-        Call_PushString(ActiveContract[client].m_sUUID);
+        Call_PushString(ActiveContract[client].UUID);
         Call_PushCell(db_id);
-        Call_PushCell(hObj.m_iProgress);
+        Call_PushCell(ActiveContract[client].ObjectiveProgress.Get(db_id));
         Call_Finish();
 
         if (g_DebugQuery.BoolValue)
         {
-            LogMessage("[ZContracts] %N LOAD: Successfully grabbed ContractObjective %d progress from database CP: (%d/%d)",
-            client, db_id, hObj.m_iProgress, hObj.m_iMaxProgress);
+            LogMessage("[ZContracts] %N LOAD: Successfully grabbed objective %d progress from database. Value: %d",
+            client, db_id, ActiveContract[client].ObjectiveProgress);
         }
     }
 

--- a/addons/sourcemod/scripting/zcontracts/contracts_database.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_database.sp
@@ -150,8 +150,8 @@ public any Native_SetObjectiveProgressDatabase(Handle plugin, int numParams)
     }
 
     // Don't save infinite objectives.
-    KeyValues Schema = GetObjectiveSchema(UUID, objective_id+1);
-    if (view_as<bool>(Schema.GetNum("infinite", 0)))
+    KeyValues Schema = GetObjectiveSchema(UUID, objective_id);
+    if (view_as<bool>(Schema.GetNum(CONTRACT_DEF_OBJ_INFINITE, 0)))
     {
         ThrowNativeError(SP_ERROR_NATIVE, "Cannot set progress for an objective that's marked infinite (UUID: %s, OBJ: %d)", UUID, objective_id);
     }
@@ -291,7 +291,7 @@ public any Native_SaveActiveObjectiveToDatabase(Handle plugin, int numParams)
 
     // Don't save infinite objectives.
     KeyValues Schema = GetObjectiveSchema(UUID, objective+1);
-    if (view_as<bool>(Schema.GetNum("infinite", 0)))
+    if (view_as<bool>(Schema.GetNum(CONTRACT_DEF_OBJ_INFINITE, 0)))
     {
         return false;
     }

--- a/addons/sourcemod/scripting/zcontracts/contracts_menu.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_menu.sp
@@ -1,6 +1,5 @@
 // Menu objects.
 static Menu gContractMenu;
-Panel gContractObjeciveDisplay[MAXPLAYERS+1];
 Panel gHelpDisplay[MAXPLAYERS+1];
 Panel gRepeatDisplay[MAXPLAYERS+1];
 char g_RepeatUUID[MAXPLAYERS+1][MAX_UUID_SIZE];
@@ -101,7 +100,7 @@ int ContractMenuHandler(Menu menu, MenuAction action, int param1, int param2)
 				}
 
 				// Are we currently using this contract?
-				if (StrEqual(MenuKey, ActiveContract[param1].m_sUUID)) 
+				if (StrEqual(MenuKey, ActiveContract[param1].UUID)) 
 				{
 					if (g_RepeatContracts.BoolValue && ActiveContract[param1].IsContractComplete())
 					{
@@ -240,7 +239,7 @@ int ContractMenuHandler(Menu menu, MenuAction action, int param1, int param2)
 				// If we're allowed to repeat Contracts, allow us to repeat
 				// our currently selected contract if it's completed.
 				else if (g_RepeatContracts.BoolValue && 
-				StrEqual(MenuKey, ActiveContract[param1].m_sUUID) &&
+				StrEqual(MenuKey, ActiveContract[param1].UUID) &&
 				ActiveContract[param1].IsContractComplete())
 				{
 					CompletedContractInfo info;
@@ -269,7 +268,7 @@ int ContractMenuHandler(Menu menu, MenuAction action, int param1, int param2)
 					}
 				}
 				// Are we NOT currently using this contract?
-				else if (!StrEqual(MenuKey, ActiveContract[param1].m_sUUID))
+				else if (!StrEqual(MenuKey, ActiveContract[param1].UUID))
 				{
 					SetClientContract(param1, MenuKey);	
 				}
@@ -338,7 +337,7 @@ void OpenContrackerForClient(int client)
 	if (ActiveContract[client].IsContractInitalized())
 	{
 		// Display our objective display instead.
-		CreateObjectiveDisplay(client, ActiveContract[client], false);
+		CreateObjectiveDisplay(client, false);
 	}
 	else
 	{
@@ -355,59 +354,64 @@ void OpenContrackerForClient(int client)
  * @param ClientContract    	Contract struct to grab Objective information from.
  * @param unknown		If true, progress values will be replaced with "?"
 **/
-void CreateObjectiveDisplay(int client, Contract ClientContract, bool unknown)
+void CreateObjectiveDisplay(int client, bool unknown)
 {
 	if (!unknown && PlayerSoundsEnabled[client] == Sounds_Enabled) EmitGameSoundToClient(client, ProgressLoadedSound);
 
-	// Construct our panel for the client.
-	delete gContractObjeciveDisplay[client];
-	gContractObjeciveDisplay[client] = new Panel();
-	char PanelTitle[128] = "\"%s\" || ";
-	Format(PanelTitle, sizeof(PanelTitle), PanelTitle, ClientContract.m_sContractName);
+	Menu ContractDisplay = new Menu(ObjectiveDisplayHandler, MENU_ACTIONS_ALL);
+	ContractDisplay.OptionFlags = MENUFLAG_NO_SOUND | MENUFLAG_BUTTON_EXIT;
+
+	char ContractName[128];
+	ActiveContract[client].CachedSchema.GetString("name", ContractName, sizeof(ContractName));
+	Format(ContractName, sizeof(ContractName), "\"%s\"", ContractName);
 	
-	// Draw difficulty text.
-	char Difficulty[32] = "Difficulty: ";
-	for (int i = 0; i < ClientContract.m_iDifficulty; i++)
+	// Add difficulty stars to our title.
+	char StrDifficulty[32] = " || Difficulty: ";
+	int Difficulty = ActiveContract[client].CachedSchema.GetNum("difficulty", 0);
+	if (Difficulty > 0)
 	{
-		StrCat(Difficulty, sizeof(Difficulty), "%s");
-		Format(Difficulty, sizeof(Difficulty), Difficulty, "★");
+		for (int i = 0; i < Difficulty; i++)
+		{
+			StrCat(StrDifficulty, sizeof(StrDifficulty), "%s");
+			Format(StrDifficulty, sizeof(StrDifficulty), StrDifficulty, "★");
+		}
+		StrCat(ContractName, sizeof(ContractName), StrDifficulty);
 	}
-	//gContractObjeciveDisplay[client].DrawText(Difficulty);
-	StrCat(PanelTitle, sizeof(PanelTitle), Difficulty);
-	gContractObjeciveDisplay[client].SetTitle(PanelTitle);
 
 	// Display the amount of times we've completed this Contract.
 	if (g_RepeatContracts.BoolValue)
 	{
 		CompletedContractInfo info;
-		CompletedContracts[client].GetArray(ClientContract.m_sUUID, info, sizeof(CompletedContractInfo));
-		char text[64] = "Completions: %d";
+		CompletedContracts[client].GetArray(ActiveContract[client].UUID, info, sizeof(CompletedContractInfo));
+		char text[64] = " || Completions: %d";
 		Format(text, sizeof(text), text, info.m_iCompletions);
-		gContractObjeciveDisplay[client].DrawText(text);
-		gContractObjeciveDisplay[client].DrawText(" ");
+		StrCat(ContractName, sizeof(ContractName), StrDifficulty);
 	}
 
-	switch (ClientContract.m_iContractType)
+	ContractDisplay.SetTitle(ContractName);
+
+	switch (ActiveContract[client].CachedSchema.GetNum("type"))
 	{
 		case Contract_ContractProgress:
 		{
+			int MaxProgress = ActiveContract[client].CachedSchema.GetNum("maximum_cp");
 			char ContractGoal[128] = "To complete this Contract, get %d CP.";
-			Format(ContractGoal, sizeof(ContractGoal), ContractGoal, ClientContract.m_iMaxProgress);
-			gContractObjeciveDisplay[client].DrawText(ContractGoal);
+			Format(ContractGoal, sizeof(ContractGoal), ContractGoal, MaxProgress);
+			ContractDisplay.AddItem("#contract_goal", ContractGoal, ITEMDRAW_DISABLED);
 
 			char ContractProgress[256];
-			Format(ContractProgress, sizeof(ContractProgress), "Progress: [%d/%d]", ClientContract.m_iProgress, ClientContract.m_iMaxProgress);
+			Format(ContractProgress, sizeof(ContractProgress), "Progress: [%d/%d]", ActiveContract[client].ContractProgress, MaxProgress);
 			if (unknown)
 			{
-				Format(ContractProgress, sizeof(ContractProgress), "Progress: [?/%d]", ClientContract.m_iMaxProgress);
+				Format(ContractProgress, sizeof(ContractProgress), "Progress: [?/%d]", MaxProgress);
 			}
-			gContractObjeciveDisplay[client].DrawText(ContractProgress);
-			gContractObjeciveDisplay[client].DrawText(" ");
+			ContractDisplay.AddItem("#contract_progress", ContractProgress, ITEMDRAW_DISABLED);
+			ContractDisplay.AddItem("#divider1", "-------------------------------------------------", ITEMDRAW_SPACER);
 		}
 		case Contract_ObjectiveProgress:
 		{
 			char ContractGoal[128];
-			if (ClientContract.m_hObjectives.Length == 1)
+			if (ActiveContract[client].ObjectiveCount == 1)
 			{
 				ContractGoal = "To complete this Contract, complete %d objective.\n";
 			}
@@ -416,61 +420,63 @@ void CreateObjectiveDisplay(int client, Contract ClientContract, bool unknown)
 				ContractGoal = "To complete this Contract, complete %d objectives.\n";
 			}
 			
-			Format(ContractGoal, sizeof(ContractGoal), ContractGoal, ClientContract.m_hObjectives.Length);
-			gContractObjeciveDisplay[client].DrawText(ContractGoal);
-			gContractObjeciveDisplay[client].DrawText(" ");
+			Format(ContractGoal, sizeof(ContractGoal), ContractGoal, ActiveContract[client].m_hObjectives.Length);
+			ContractDisplay.AddItem("#contract_goal", ContractGoal, ITEMDRAW_DISABLED);
+			ContractDisplay.AddItem("#divider2", "-------------------------------------------------", ITEMDRAW_SPACER);
 		}
 	}
 
 	// TODO: Should we split this up into two pages?
-	for (int i = 0; i < ClientContract.m_hObjectives.Length; i++)
+	for (int obj_id = 0; obj_id < ActiveContract[client].ObjectiveCount; obj_id++)
 	{
-		ContractObjective Objective;
-		ClientContract.GetObjective(i, Objective);
-
+		KeyValues ObjSchema = ActiveContract[client].CachedObjSchema.Get(obj_id);
 		char line[256];
-		if (Objective.m_bInfinite)
+		char Description[256];
+		ObjSchema.GetString("description", Description, sizeof(Description));
+		int MaxProgress = ObjSchema.GetNum("maximum_cp");
+		int Award = ObjSchema.GetNum("award");
+
+		if (ActiveContract[client].IsObjectiveInfinite(obj_id))
 		{
-			Format(line, sizeof(line), "Objective #%d: \"%s\" +%dCP", i+1,
-			Objective.m_sDescription, Objective.m_iAward);
+			Format(line, sizeof(line), "Objective #%d: \"%s\" +%dCP", obj_id+1, Description, Award);
 		}
 		else
 		{
-			switch (ClientContract.m_iContractType)
+			switch (ActiveContract[client].CachedSchema.GetNum("type"))
 			{
 				case Contract_ObjectiveProgress:
 				{
-					Format(line, sizeof(line), "Objective #%d: \"%s\" [%d/%d]", i+1,
-					Objective.m_sDescription, Objective.m_iProgress, Objective.m_iMaxProgress);
+					Format(line, sizeof(line), "Objective #%d: \"%s\" [%d/%d]", obj_id+1,
+					Description, ActiveContract[client].ObjectiveProgress.Get(obj_id), MaxProgress);
 					
 					if (unknown)
 					{
-						Format(line, sizeof(line), "Objective #%d: \"%s\" [?/%d]", i+1,
-						Objective.m_sDescription, Objective.m_iMaxProgress);
+						Format(line, sizeof(line), "Objective #%d: \"%s\" [?/%d]", obj_id+1, Description, MaxProgress);
 					}
 
 				}
 				case Contract_ContractProgress:
 				{
-					Format(line, sizeof(line), "Objective #%d: \"%s\" [%d/%d] +%dCP", i+1,
-					Objective.m_sDescription, Objective.m_iProgress, Objective.m_iMaxProgress, Objective.m_iAward);
+					Format(line, sizeof(line), "Objective #%d: \"%s\" [%d/%d] +%dCP", obj_id+1,
+					Description, ActiveContract[client].ObjectiveProgress.Get(obj_id), MaxProgress, Award);
 					if (unknown)
 					{
-						Format(line, sizeof(line), "Objective #%d: \"%s\" [?/%d] +%dCP", i+1,
-						Objective.m_sDescription, Objective.m_iMaxProgress, Objective.m_iAward);				
+						Format(line, sizeof(line), "Objective #%d: \"%s\" [?/%d] +%dCP", obj_id+1,
+						Description, MaxProgress, Award);				
 					}
 				}
 			}
 		}
-		gContractObjeciveDisplay[client].DrawText(line);
+		char MenuKey[8];
+		Format(MenuKey, sizeof(MenuKey), "obj_%d", obj_id);
+		ContractDisplay.AddItem(MenuKey, line);	
 	}
 	
-	gContractObjeciveDisplay[client].DrawText(" ");
+	ContractDisplay.AddItem("#divider3", "-------------------------------------------------", ITEMDRAW_SPACER);
 
 	// Send this to our client.
-	gContractObjeciveDisplay[client].DrawItem("Open Contracker");
-	gContractObjeciveDisplay[client].DrawItem("Close");
-	gContractObjeciveDisplay[client].Send(client, ObjectiveDisplayHandler, 20);
+	ContractDisplay.AddItem("open", "Open Contracker");
+	ContractDisplay.Display(client, 20);
 }
 
 /**
@@ -478,15 +484,180 @@ void CreateObjectiveDisplay(int client, Contract ClientContract, bool unknown)
 **/
 public int ObjectiveDisplayHandler(Menu menu, MenuAction action, int param1, int param2)
 {
-	if (action == MenuAction_Select)
-    {
-		if (param2 == 1)
+	int style;
+	char MenuKey[MAX_UUID_SIZE];
+	char MenuDisplay[MAX_NAME_LENGTH+32]; // Display name (+32 for anything else added after the name)
+	menu.GetItem(param2, MenuKey, sizeof(MenuKey), style, MenuDisplay, sizeof(MenuDisplay));
+	
+	switch (action)
+	{
+		case MenuAction_DrawItem:
 		{
-			gContractMenu.Display(param1, MENU_TIME_FOREVER);
+			if (MenuKey[0] == '#') return ITEMDRAW_DISABLED;
+			if (StrContains(MenuKey, "#divider") != -1) return ITEMDRAW_DISABLED | ITEMDRAW_SPACER;
+
+			if (StrContains(MenuKey, "obj_") != -1)
+			{
+				// Format: obj_###
+				ReplaceString(MenuDisplay, sizeof(MenuDisplay), "obj_", "");
+				int Objective = StringToInt(MenuDisplay);
+
+				KeyValues ObjSchema = ActiveContract[param1].CachedObjSchema.Get(Objective);
+				char ExtendedDesc[64];
+				ObjSchema.GetString("extended_description", ExtendedDesc, sizeof(ExtendedDesc), "");
+				if (StrEqual(ExtendedDesc, ""))
+				{
+					return ITEMDRAW_DISABLED;
+				}
+				return ITEMDRAW_DEFAULT;
+			}
+		
+			else return ITEMDRAW_DEFAULT;
 		}
-    }
+		case MenuAction_DisplayItem:
+		{
+			if (StrContains(MenuKey, "obj_") != -1)
+			{
+				// Format: obj_###
+				ReplaceString(MenuDisplay, sizeof(MenuDisplay), "obj_", "");
+				int Objective = StringToInt(MenuDisplay);
+
+				KeyValues ObjSchema = ActiveContract[param1].CachedObjSchema.Get(Objective);
+				char ExtendedDesc[64];
+				ObjSchema.GetString("extended_description", ExtendedDesc, sizeof(ExtendedDesc));
+				if (!StrEqual(ExtendedDesc, ""))
+				{
+					StrCat(MenuDisplay, sizeof(MenuDisplay), " (...)");
+					return RedrawMenuItem(MenuDisplay);
+				}
+			}
+			
+		}
+		case MenuAction_Select:
+		{
+			if (StrEqual(MenuKey, "open"))
+			{
+				gContractMenu.Display(param1, MENU_TIME_FOREVER);
+			}
+			else if (StrContains(MenuKey, "obj_") != -1)
+			{
+				// Format: obj_###
+				ReplaceString(MenuDisplay, sizeof(MenuDisplay), "obj_", "");
+				int Objective = StringToInt(MenuDisplay);
+
+				KeyValues ObjSchema = ActiveContract[param1].CachedObjSchema.Get(Objective);
+				char ExtendedDesc[64];
+				ObjSchema.GetString("extended_description", ExtendedDesc, sizeof(ExtendedDesc));
+				if (!StrEqual(ExtendedDesc, ""))
+				{
+					ConstructObjectiveInformationMenu(param1, Objective);
+				}
+			}
+		}
+	}
 	return 0;
 }
+
+void ConstructObjectiveInformationMenu(int client, int objective)
+{
+	// Construct our panel for the client.
+	Menu ObjectiveInformation = new Menu(ObjectiveInformationHandler, MENU_ACTIONS_ALL);
+	ObjectiveInformation.OptionFlags = MENUFLAG_NO_SOUND | MENUFLAG_BUTTON_EXIT;
+
+	char ContractName[128];
+	ActiveContract[client].CachedSchema.GetString("name", ContractName, sizeof(ContractName));
+	Format(ContractName, sizeof(ContractName), "\"%s\"", ContractName);
+	
+	// Add difficulty stars to our title.
+	char StrDifficulty[32] = " || Difficulty: ";
+	int Difficulty = ActiveContract[client].CachedSchema.GetNum("difficulty", 0);
+	if (Difficulty > 0)
+	{
+		for (int i = 0; i < Difficulty; i++)
+		{
+			StrCat(StrDifficulty, sizeof(StrDifficulty), "%s");
+			Format(StrDifficulty, sizeof(StrDifficulty), StrDifficulty, "★");
+		}
+		StrCat(ContractName, sizeof(ContractName), StrDifficulty);
+	}
+
+	// Display the amount of times we've completed this Contract.
+	if (g_RepeatContracts.BoolValue)
+	{
+		CompletedContractInfo info;
+		CompletedContracts[client].GetArray(ActiveContract[client].UUID, info, sizeof(CompletedContractInfo));
+		char text[64] = " || Completions: %d";
+		Format(text, sizeof(text), text, info.m_iCompletions);
+		StrCat(ContractName, sizeof(ContractName), StrDifficulty);
+	}
+
+	ObjectiveInformation.SetTitle(ContractName);
+	KeyValues ObjSchema = ActiveContract[client].CachedObjSchema.Get(objective);
+	
+	char ExtendedDesc[256];
+	ObjSchema.GetString("extended_description", ExtendedDesc, sizeof(ExtendedDesc), "");
+
+	// For some reason, ExplodeString and ReplaceString don't want to deal with
+	// newline characters. As a hack, I will split strings with # instead.
+	char DescStrings[8][128];
+	int StringCount = ExplodeString(ExtendedDesc, "#", DescStrings, sizeof(DescStrings), sizeof(DescStrings[]));
+	for (int i = 0; i < StringCount; i++)
+	{
+		char StringToAdd[128];
+		if (i == 0)
+		{
+			Format(StringToAdd, sizeof(StringToAdd), "Objective Description: \"%s", DescStrings[i]);
+		}
+		else if (i == StringCount-1)
+		{
+			Format(StringToAdd, sizeof(StringToAdd), "%s\"", DescStrings[i]);
+		}
+		else
+		{
+			StringToAdd = DescStrings[i];
+		}
+		char Key[16];
+		Format(Key, sizeof(Key), "desc_%d", i);
+		ObjectiveInformation.AddItem(Key, StringToAdd);
+	}
+
+	ObjectiveInformation.AddItem("return", "Return to Contract");
+	ObjectiveInformation.AddItem("open", "Open Contracker");
+	ObjectiveInformation.Display(client, 20);
+}
+
+public int ObjectiveInformationHandler(Menu menu, MenuAction action, int param1, int param2)
+{
+	int style;
+	char MenuKey[MAX_UUID_SIZE];
+	char MenuDisplay[MAX_NAME_LENGTH+32]; // Display name (+32 for anything else added after the name)
+	menu.GetItem(param2, MenuKey, sizeof(MenuKey), style, MenuDisplay, sizeof(MenuDisplay));
+	
+	switch (action)
+	{
+		case MenuAction_DrawItem:
+		{
+			if (StrContains(MenuKey, "desc_") != -1)
+			{
+				return ITEMDRAW_DISABLED;
+			}
+			else return ITEMDRAW_DEFAULT;
+		}
+		case MenuAction_Select:
+		{
+			if (StrEqual(MenuKey, "open"))
+			{
+				gContractMenu.Display(param1, MENU_TIME_FOREVER);
+			}
+			else if (StrEqual(MenuKey, "return"))
+			{
+				CreateObjectiveDisplay(param1, false);
+			}
+		}
+	}
+	return 0;
+}
+
 
 void ConstructHelpPanel(int client)
 {
@@ -532,14 +703,7 @@ public Action OpenHelpPanelCmd(int client, int args)
 void CreateLockedContractMenu(int client, char UUID[MAX_UUID_SIZE])
 {
 	// Grab the Contract from the schema.
-	KeyValues LockedContract = new KeyValues("Contract");
-	if (!g_ContractSchema.JumpToKey(UUID))
-	{
-		// How the hell did we get here?
-		ThrowError("%N somehow selected an invalid, locked Contract!? UUID: %s", client, UUID);
-	}
-	KvCopySubkeys(g_ContractSchema, LockedContract);
-	g_ContractSchema.Rewind();
+	KeyValues LockedContract = GetContractSchema(UUID);
 
 	Menu ClientMenu = new Menu(LockedContractMenuHandler, MENU_ACTIONS_ALL);
 	char ContractNameText[MAX_CONTRACT_NAME_SIZE + 32] = "\"%s\" cannot be activated.";
@@ -597,11 +761,8 @@ int LockedContractMenuHandler(Menu menu, MenuAction action, int param1, int para
 			// Are we a contract?
 			if (MenuKey[0] == '{')
 			{
-				Contract ClientContract;
-				GetClientContractStruct(param1, ClientContract);
-
 				// Are we currently using this contract?
-				if (StrEqual(MenuKey, ClientContract.m_sUUID)) 
+				if (StrEqual(MenuKey, ActiveContract[param1].UUID)) 
 				{
 					return ITEMDRAW_DISABLED;
 				}
@@ -623,11 +784,8 @@ int LockedContractMenuHandler(Menu menu, MenuAction action, int param1, int para
 			// Is this a Contract?
 			if (MenuKey[0] == '{')
 			{
-				Contract ClientContract;
-				GetClientContractStruct(param1, ClientContract);
-
 				// Are we doing this Contract?
-				if (StrEqual(ClientContract.m_sUUID, MenuKey))
+				if (StrEqual(ActiveContract[param1].UUID, MenuKey))
 				{
 					Format(MenuDisplay, sizeof(MenuDisplay), "%s [ACTIVE]", MenuDisplay);
 					return RedrawMenuItem(MenuDisplay);
@@ -666,11 +824,10 @@ int LockedContractMenuHandler(Menu menu, MenuAction action, int param1, int para
 					delete menu;
 				}
 				// Are we NOT currently using this contract?
-				else if (!StrEqual(MenuKey, ActiveContract[param1].m_sUUID))
+				else if (!StrEqual(MenuKey, ActiveContract[param1].UUID))
 				{
 					SetClientContract(param1, MenuKey);	
 				}
-				
 			}
 		}
 
@@ -690,14 +847,11 @@ void ConstructRepeatContractPanel(int client, const char[] UUID)
 	gRepeatDisplay[client] = new Panel();
 	gRepeatDisplay[client].SetTitle("ZContracts - Repeat Contract");
 
-	// Grab the Contract name with a little bit of schema tomfoolery.
-	if (!g_ContractSchema.JumpToKey(UUID))
-	{
-		ThrowError("How the fuck did we get here?");
-	}
+	// Grab the Contract from the schema.
+	KeyValues LockedContract = GetContractSchema(UUID);
+
 	char ContractName[MAX_CONTRACT_NAME_SIZE];
-	g_ContractSchema.GetString("name", ContractName, sizeof(ContractName));
-	g_ContractSchema.Rewind();
+	LockedContract.GetString("name", ContractName, sizeof(ContractName));
 
 	char PromptText[128] = "Do you wish to reset your progress for \"%s\"";
 	Format(PromptText, sizeof(PromptText), PromptText, ContractName);

--- a/addons/sourcemod/scripting/zcontracts/contracts_menu.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_menu.sp
@@ -570,16 +570,13 @@ void ConstructObjectiveInformationMenu(int client, int objective)
 	
 	// Add difficulty stars to our title.
 	char StrDifficulty[32] = " || Difficulty: ";
-	int Difficulty = ActiveContract[client].GetSchema().GetNum(CONTRACT_DEF_DIFFICULTY, 0);
-	if (Difficulty > 0)
+	int Difficulty = ActiveContract[client].GetSchema().GetNum(CONTRACT_DEF_DIFFICULTY, 1);
+	for (int i = 0; i < Difficulty; i++)
 	{
-		for (int i = 0; i < Difficulty; i++)
-		{
-			StrCat(StrDifficulty, sizeof(StrDifficulty), "%s");
-			Format(StrDifficulty, sizeof(StrDifficulty), StrDifficulty, "★");
-		}
-		StrCat(ContractName, sizeof(ContractName), StrDifficulty);
+		StrCat(StrDifficulty, sizeof(StrDifficulty), "%s");
+		Format(StrDifficulty, sizeof(StrDifficulty), StrDifficulty, "★");
 	}
+	StrCat(ContractName, sizeof(ContractName), StrDifficulty);
 
 	// Display the amount of times we've completed this Contract.
 	if (g_RepeatContracts.BoolValue)

--- a/addons/sourcemod/scripting/zcontracts/contracts_menu.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_menu.sp
@@ -193,7 +193,7 @@ int ContractMenuHandler(Menu menu, MenuAction action, int param1, int param2)
 					return RedrawMenuItem(MenuDisplay);
 				}
 
-				if (StrEqual(ActiveContract[param1].m_sUUID, MenuKey))
+				if (StrEqual(ActiveContract[param1].UUID, MenuKey))
 				{
 					Format(MenuDisplay, sizeof(MenuDisplay), "%s [ACTIVE]", MenuDisplay);
 					return RedrawMenuItem(MenuDisplay);
@@ -243,10 +243,10 @@ int ContractMenuHandler(Menu menu, MenuAction action, int param1, int param2)
 				ActiveContract[param1].IsContractComplete())
 				{
 					CompletedContractInfo info;
-					CompletedContracts[param1].GetArray(ActiveContract[param1].m_sUUID, info, sizeof(CompletedContractInfo));
+					CompletedContracts[param1].GetArray(ActiveContract[param1].UUID, info, sizeof(CompletedContractInfo));
 					if (!info.m_bReset)
 					{
-						ConstructRepeatContractPanel(param1, ActiveContract[param1].m_sUUID);
+						ConstructRepeatContractPanel(param1, ActiveContract[param1].UUID);
 					}
 					else 
 					{
@@ -390,7 +390,7 @@ void CreateObjectiveDisplay(int client, bool unknown)
 
 	ContractDisplay.SetTitle(ContractName);
 
-	switch (ActiveContract[client].CachedSchema.GetNum("type"))
+	switch (view_as<ContractType>(ActiveContract[client].CachedSchema.GetNum("type")))
 	{
 		case Contract_ContractProgress:
 		{
@@ -420,7 +420,7 @@ void CreateObjectiveDisplay(int client, bool unknown)
 				ContractGoal = "To complete this Contract, complete %d objectives.\n";
 			}
 			
-			Format(ContractGoal, sizeof(ContractGoal), ContractGoal, ActiveContract[client].m_hObjectives.Length);
+			Format(ContractGoal, sizeof(ContractGoal), ContractGoal, ActiveContract[client].ObjectiveCount);
 			ContractDisplay.AddItem("#contract_goal", ContractGoal, ITEMDRAW_DISABLED);
 			ContractDisplay.AddItem("#divider2", "-------------------------------------------------", ITEMDRAW_SPACER);
 		}
@@ -442,7 +442,7 @@ void CreateObjectiveDisplay(int client, bool unknown)
 		}
 		else
 		{
-			switch (ActiveContract[client].CachedSchema.GetNum("type"))
+			switch (view_as<ContractType>(ActiveContract[client].CachedSchema.GetNum("type")))
 			{
 				case Contract_ObjectiveProgress:
 				{
@@ -842,7 +842,7 @@ int LockedContractMenuHandler(Menu menu, MenuAction action, int param1, int para
 	return 0;
 }
 
-void ConstructRepeatContractPanel(int client, const char[] UUID)
+void ConstructRepeatContractPanel(int client, char UUID[MAX_UUID_SIZE])
 {
 	gRepeatDisplay[client] = new Panel();
 	gRepeatDisplay[client].SetTitle("ZContracts - Repeat Contract");

--- a/addons/sourcemod/scripting/zcontracts/contracts_menu.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_menu.sp
@@ -592,7 +592,7 @@ void ConstructObjectiveInformationMenu(int client, int objective)
 	KeyValues ObjSchema = ActiveContract[client].GetObjectiveSchema(objective);
 	
 	char ExtendedDesc[256];
-	ObjSchema.GetString(CONTRACT_DEF_OBJ_DESC, ExtendedDesc, sizeof(ExtendedDesc), "");
+	ObjSchema.GetString(CONTRACT_DEF_OBJ_EXT_DESC, ExtendedDesc, sizeof(ExtendedDesc), "");
 
 	// For some reason, ExplodeString and ReplaceString don't want to deal with
 	// newline characters. As a hack, I will split strings with # instead.

--- a/addons/sourcemod/scripting/zcontracts/contracts_menu.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_menu.sp
@@ -49,7 +49,7 @@ void CreateContractMenu()
 			char sUUID[MAX_UUID_SIZE];
 			g_ContractSchema.GetSectionName(sUUID, sizeof(sUUID));
 			char sContractName[MAX_CONTRACT_NAME_SIZE];
-			g_ContractSchema.GetString("name", sContractName, sizeof(sContractName), "undefined");
+			g_ContractSchema.GetString(CONTRACT_DEF_NAME, sContractName, sizeof(sContractName), "undefined");
 			gContractMenu.AddItem(sUUID, sContractName);
 		}
 		while(g_ContractSchema.GotoNextKey());
@@ -362,12 +362,12 @@ void CreateObjectiveDisplay(int client, bool unknown)
 	ContractDisplay.OptionFlags = MENUFLAG_NO_SOUND | MENUFLAG_BUTTON_EXIT;
 
 	char ContractName[128];
-	ActiveContract[client].CachedSchema.GetString("name", ContractName, sizeof(ContractName));
+	ActiveContract[client].GetSchema().GetString(CONTRACT_DEF_NAME, ContractName, sizeof(ContractName));
 	Format(ContractName, sizeof(ContractName), "\"%s\"", ContractName);
 	
 	// Add difficulty stars to our title.
 	char StrDifficulty[32] = " || Difficulty: ";
-	int Difficulty = ActiveContract[client].CachedSchema.GetNum("difficulty", 0);
+	int Difficulty = ActiveContract[client].GetSchema().GetNum(CONTRACT_DEF_DIFFICULTY, 0);
 	if (Difficulty > 0)
 	{
 		for (int i = 0; i < Difficulty; i++)
@@ -390,11 +390,11 @@ void CreateObjectiveDisplay(int client, bool unknown)
 
 	ContractDisplay.SetTitle(ContractName);
 
-	switch (view_as<ContractType>(ActiveContract[client].CachedSchema.GetNum("type")))
+	switch (view_as<ContractType>(ActiveContract[client].GetSchema().GetNum(CONTRACT_DEF_TYPE)))
 	{
 		case Contract_ContractProgress:
 		{
-			int MaxProgress = ActiveContract[client].CachedSchema.GetNum("maximum_cp");
+			int MaxProgress = ActiveContract[client].GetSchema().GetNum(CONTRACT_DEF_MAX_PROGRESS);
 			char ContractGoal[128] = "To complete this Contract, get %d CP.";
 			Format(ContractGoal, sizeof(ContractGoal), ContractGoal, MaxProgress);
 			ContractDisplay.AddItem("#contract_goal", ContractGoal, ITEMDRAW_DISABLED);
@@ -429,12 +429,12 @@ void CreateObjectiveDisplay(int client, bool unknown)
 	// TODO: Should we split this up into two pages?
 	for (int obj_id = 0; obj_id < ActiveContract[client].ObjectiveCount; obj_id++)
 	{
-		KeyValues ObjSchema = ActiveContract[client].CachedObjSchema.Get(obj_id);
+		KeyValues ObjSchema = ActiveContract[client].GetObjectiveSchema(obj_id);
 		char line[256];
 		char Description[256];
-		ObjSchema.GetString("description", Description, sizeof(Description));
-		int MaxProgress = ObjSchema.GetNum("maximum_cp");
-		int Award = ObjSchema.GetNum("award");
+		ObjSchema.GetString(CONTRACT_DEF_OBJ_DESC, Description, sizeof(Description));
+		int MaxProgress = ObjSchema.GetNum(CONTRACT_DEF_OBJ_MAX_PROGRESS);
+		int Award = ObjSchema.GetNum(CONTRACT_DEF_OBJ_AWARD);
 
 		if (ActiveContract[client].IsObjectiveInfinite(obj_id))
 		{
@@ -442,7 +442,7 @@ void CreateObjectiveDisplay(int client, bool unknown)
 		}
 		else
 		{
-			switch (view_as<ContractType>(ActiveContract[client].CachedSchema.GetNum("type")))
+			switch (view_as<ContractType>(ActiveContract[client].GetSchema().GetNum(CONTRACT_DEF_TYPE)))
 			{
 				case Contract_ObjectiveProgress:
 				{
@@ -502,9 +502,9 @@ public int ObjectiveDisplayHandler(Menu menu, MenuAction action, int param1, int
 				ReplaceString(MenuDisplay, sizeof(MenuDisplay), "obj_", "");
 				int Objective = StringToInt(MenuDisplay);
 
-				KeyValues ObjSchema = ActiveContract[param1].CachedObjSchema.Get(Objective);
+				KeyValues ObjSchema = ActiveContract[param1].GetObjectiveSchema(Objective);
 				char ExtendedDesc[64];
-				ObjSchema.GetString("extended_description", ExtendedDesc, sizeof(ExtendedDesc), "");
+				ObjSchema.GetString(CONTRACT_DEF_OBJ_EXT_DESC, ExtendedDesc, sizeof(ExtendedDesc), "");
 				if (StrEqual(ExtendedDesc, ""))
 				{
 					return ITEMDRAW_DISABLED;
@@ -522,9 +522,9 @@ public int ObjectiveDisplayHandler(Menu menu, MenuAction action, int param1, int
 				ReplaceString(MenuDisplay, sizeof(MenuDisplay), "obj_", "");
 				int Objective = StringToInt(MenuDisplay);
 
-				KeyValues ObjSchema = ActiveContract[param1].CachedObjSchema.Get(Objective);
+				KeyValues ObjSchema = ActiveContract[param1].GetObjectiveSchema(Objective);
 				char ExtendedDesc[64];
-				ObjSchema.GetString("extended_description", ExtendedDesc, sizeof(ExtendedDesc));
+				ObjSchema.GetString(CONTRACT_DEF_OBJ_EXT_DESC, ExtendedDesc, sizeof(ExtendedDesc));
 				if (!StrEqual(ExtendedDesc, ""))
 				{
 					StrCat(MenuDisplay, sizeof(MenuDisplay), " (...)");
@@ -545,9 +545,9 @@ public int ObjectiveDisplayHandler(Menu menu, MenuAction action, int param1, int
 				ReplaceString(MenuDisplay, sizeof(MenuDisplay), "obj_", "");
 				int Objective = StringToInt(MenuDisplay);
 
-				KeyValues ObjSchema = ActiveContract[param1].CachedObjSchema.Get(Objective);
+				KeyValues ObjSchema = ActiveContract[param1].GetObjectiveSchema(Objective);
 				char ExtendedDesc[64];
-				ObjSchema.GetString("extended_description", ExtendedDesc, sizeof(ExtendedDesc));
+				ObjSchema.GetString(CONTRACT_DEF_OBJ_EXT_DESC, ExtendedDesc, sizeof(ExtendedDesc));
 				if (!StrEqual(ExtendedDesc, ""))
 				{
 					ConstructObjectiveInformationMenu(param1, Objective);
@@ -565,12 +565,12 @@ void ConstructObjectiveInformationMenu(int client, int objective)
 	ObjectiveInformation.OptionFlags = MENUFLAG_NO_SOUND | MENUFLAG_BUTTON_EXIT;
 
 	char ContractName[128];
-	ActiveContract[client].CachedSchema.GetString("name", ContractName, sizeof(ContractName));
+	ActiveContract[client].GetSchema().GetString(CONTRACT_DEF_NAME, ContractName, sizeof(ContractName));
 	Format(ContractName, sizeof(ContractName), "\"%s\"", ContractName);
 	
 	// Add difficulty stars to our title.
 	char StrDifficulty[32] = " || Difficulty: ";
-	int Difficulty = ActiveContract[client].CachedSchema.GetNum("difficulty", 0);
+	int Difficulty = ActiveContract[client].GetSchema().GetNum(CONTRACT_DEF_DIFFICULTY, 0);
 	if (Difficulty > 0)
 	{
 		for (int i = 0; i < Difficulty; i++)
@@ -592,10 +592,10 @@ void ConstructObjectiveInformationMenu(int client, int objective)
 	}
 
 	ObjectiveInformation.SetTitle(ContractName);
-	KeyValues ObjSchema = ActiveContract[client].CachedObjSchema.Get(objective);
+	KeyValues ObjSchema = ActiveContract[client].GetObjectiveSchema(objective);
 	
 	char ExtendedDesc[256];
-	ObjSchema.GetString("extended_description", ExtendedDesc, sizeof(ExtendedDesc), "");
+	ObjSchema.GetString(CONTRACT_DEF_OBJ_DESC, ExtendedDesc, sizeof(ExtendedDesc), "");
 
 	// For some reason, ExplodeString and ReplaceString don't want to deal with
 	// newline characters. As a hack, I will split strings with # instead.
@@ -708,7 +708,7 @@ void CreateLockedContractMenu(int client, char UUID[MAX_UUID_SIZE])
 	Menu ClientMenu = new Menu(LockedContractMenuHandler, MENU_ACTIONS_ALL);
 	char ContractNameText[MAX_CONTRACT_NAME_SIZE + 32] = "\"%s\" cannot be activated.";
 	char ContractName[MAX_CONTRACT_NAME_SIZE];
-	LockedContract.GetString("name", ContractName, sizeof(ContractName));
+	LockedContract.GetString(CONTRACT_DEF_NAME, ContractName, sizeof(ContractName));
 	Format(ContractNameText, sizeof(ContractNameText), ContractNameText, ContractName);
 
 	ClientMenu.SetTitle("ZContracts - Locked Contract");
@@ -734,7 +734,7 @@ void CreateLockedContractMenu(int client, char UUID[MAX_UUID_SIZE])
 			// Grab the name of this Contract.
 			if (!g_ContractSchema.JumpToKey(ContractUUID)) continue;
 			char DisplayName[MAX_CONTRACT_NAME_SIZE];
-			g_ContractSchema.GetString("name", DisplayName, sizeof(DisplayName));
+			g_ContractSchema.GetString(CONTRACT_DEF_NAME, DisplayName, sizeof(DisplayName));
 			g_ContractSchema.Rewind();
 
 			ClientMenu.AddItem(ContractUUID, DisplayName);
@@ -851,7 +851,7 @@ void ConstructRepeatContractPanel(int client, char UUID[MAX_UUID_SIZE])
 	KeyValues LockedContract = GetContractSchema(UUID);
 
 	char ContractName[MAX_CONTRACT_NAME_SIZE];
-	LockedContract.GetString("name", ContractName, sizeof(ContractName));
+	LockedContract.GetString(CONTRACT_DEF_NAME, ContractName, sizeof(ContractName));
 
 	char PromptText[128] = "Do you wish to reset your progress for \"%s\"";
 	Format(PromptText, sizeof(PromptText), PromptText, ContractName);

--- a/addons/sourcemod/scripting/zcontracts/contracts_menu.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_menu.sp
@@ -91,6 +91,8 @@ int ContractMenuHandler(Menu menu, MenuAction action, int param1, int param2)
 			// Are we a contract?
 			else if (MenuKey[0] == '{')
 			{
+				KeyValues Schema = GetContractSchema(MenuKey);
+
 				char ContractDirectory[MAX_DIRECTORY_SIZE];
 				GetContractDirectory(MenuKey, ContractDirectory);
 				// Are we in the right directory?
@@ -98,6 +100,12 @@ int ContractMenuHandler(Menu menu, MenuAction action, int param1, int param2)
 				{
 					return ITEMDRAW_IGNORE;
 				}
+
+				// Admin check.
+				char AdminFlags[64];
+				Schema.GetString(CONTRACT_DEF_REQUIRED_FLAG, AdminFlags, sizeof(AdminFlags));
+				int RequiredFlags = ReadFlagString(AdminFlags);
+				if (!StrEqual(AdminFlags, "") && !(RequiredFlags && GetUserFlagBits(param1) & RequiredFlags)) return ITEMDRAW_IGNORE;
 
 				// Are we currently using this contract?
 				if (StrEqual(MenuKey, ActiveContract[param1].UUID)) 
@@ -120,6 +128,13 @@ int ContractMenuHandler(Menu menu, MenuAction action, int param1, int param2)
 				{
 					return ITEMDRAW_IGNORE;
 				}
+
+				// Do not draw a directory if it's listed as an admin-only directory.
+				/*char DictAdminString[64];
+				g_AdminDictList.GetString(MenuKey, DictAdminString, sizeof(DictAdminString))
+				PrintToChat(param1, DictAdminString);
+				int RequiredFlags = ReadFlagString(DictAdminString);
+				if (!StrEqual(DictAdminString, "") && !(RequiredFlags && GetUserFlagBits(param1) & RequiredFlags)) return ITEMDRAW_IGNORE;*/
 
 				// Depending on our deepness, see how many times the slash character shows
 				// up in this directory choice. If there's more than there should be, don't

--- a/addons/sourcemod/scripting/zcontracts/contracts_schema.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_schema.sp
@@ -45,6 +45,9 @@ public KeyValues LoadContractsSchema()
 		char requiredExt[16];
 		g_RequiredFileExt.GetString(requiredExt, sizeof(requiredExt));
 		if (StrContains(contractFilePath, requiredExt) == -1) continue;
+
+		// Don't load special config files.
+		if (StrContains(contractFilePath, "admin_directories.txt") != -1) continue;
 		
 		// Import in this config file.
 		KeyValues importKV = new KeyValues("Contract");

--- a/addons/sourcemod/scripting/zcontracts/contracts_schema.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_schema.sp
@@ -94,7 +94,7 @@ public void ProcessContractsSchema()
 		do
 		{
 			char sDirectory[MAX_DIRECTORY_SIZE];
-			g_ContractSchema.GetString("directory", sDirectory, sizeof(sDirectory), "root");
+			g_ContractSchema.GetString(CONTRACT_DEF_DIRECTORY, sDirectory, sizeof(sDirectory), "root");
 			// Add our new directory into the directory register.
 			if (g_Directories.FindString(sDirectory) == -1)
 			{
@@ -175,6 +175,7 @@ public any Native_GetObjectiveSchema(Handle plugin, int numParams)
 
 			return view_as<KeyValues>(Schema);
 		}
+		ObjectiveCount++;
 	} while (g_ContractSchema.GotoNextKey());
 
 	// Error out once more because we couldn't find the objective!
@@ -220,7 +221,7 @@ bool GetContractDirectory(const char[] sUUID, char buffer[MAX_DIRECTORY_SIZE])
 {
 	if (g_ContractSchema.JumpToKey(sUUID))
 	{
-		g_ContractSchema.GetString("directory", buffer, sizeof(buffer), "root");
+		g_ContractSchema.GetString(CONTRACT_DEF_DIRECTORY, buffer, sizeof(buffer), "root");
 		g_ContractSchema.GoBack();
 		return true;
 	}

--- a/addons/sourcemod/scripting/zcontracts/contracts_schema.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_schema.sp
@@ -168,7 +168,6 @@ public void CreateContract(KeyValues hContractConf, Contract hContract)
 	hContract.m_bNoMultiplication = view_as<bool>(hContractConf.GetNum("no_multiply", 0));
 	hContract.m_iContractType = view_as<ContractType>(hContractConf.GetNum("type", view_as<int>(Contract_ObjectiveProgress))); // stops a warning
 	hContract.m_iMaxProgress = hContractConf.GetNum("maximum_cp", -1);
-	hContract.m_iDifficulty = hContractConf.GetNum("difficulty", 1);
 	
 	// Create our objectives.
 	if (hContractConf.JumpToKey("objectives", false))
@@ -309,9 +308,6 @@ public any Native_GetObjectiveSchema(Handle plugin, int numParams)
 			NewKV.Import(g_ContractSchema);
 			g_ContractSchema.Rewind();
 			Handle Schema = CloneHandle(NewKV, plugin);
-
-			char f[128];
-			NewKV.ExportToString(f, sizeof(f));
 
 			return view_as<KeyValues>(Schema);
 		}

--- a/addons/sourcemod/scripting/zcontracts/contracts_timers.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_timers.sp
@@ -97,13 +97,13 @@ public void SendEventToTimer(int client, int obj_id, char event[MAX_EVENT_SIZE],
 			case Contract_ContractProgress: ModifyContractProgress(client, Value, ActiveContract[client], obj_id);
 		}
 	}
-	if (StrContains(EventAction, "threshold") != -1)
+	/*if (StrContains(EventAction, "threshold") != -1)
 	{
 		int curr_threshold = ActiveContract[client].ObjectiveThreshold.Get(obj_id);
 		int Value = view_as<int>(Variable);
 		if (StrContains(EventAction, "subtract") != -1) Value *= -1;
 		ActiveContract[client].ObjectiveThreshold.Set(obj_id, curr_threshold + Value);
-	}
+	}*/
 
 	if (StrEqual(EventAction, "add_time")) g_TimeChange[client] = Variable;
 	if (StrEqual(EventAction, "subtract_time")) g_TimeChange[client] = Variable * -1.0;

--- a/addons/sourcemod/scripting/zcontracts/contracts_timers.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_timers.sp
@@ -21,7 +21,7 @@ public Action EventTimer(Handle hTimer, DataPack hPack)
 	if (g_TimerActive[client] == false)
 	{
 		// Grab the starting time from the Schema.
-		KeyValues Schema = ActiveContract[client].CachedObjSchema.Get(obj_id);
+		KeyValues Schema = ActiveContract[client].GetObjectiveSchema(obj_id);
 		if (!Schema.JumpToKey("events")) ThrowError("Contract \"%s\" doesn't have any events! Fix this, server developer!", ActiveContract[client].UUID);
 		if (!Schema.JumpToKey(event)) ThrowError("Contract \"%s\" doesn't have requested event \"%s\"", ActiveContract[client].UUID, event);
 		Schema.JumpToKey("timer");
@@ -66,10 +66,10 @@ public Action EventTimer(Handle hTimer, DataPack hPack)
 public void SendEventToTimer(int client, int obj_id, char event[MAX_EVENT_SIZE], const char[] timer_event)
 {
 	// Grab the starting time from the Schema.
-	KeyValues Schema = ActiveContract[client].CachedObjSchema.Get(obj_id);
-	if (!Schema.JumpToKey("events")) ThrowError("Contract \"%s\" doesn't have any events! Fix this, server developer!", ActiveContract[client].UUID);
+	KeyValues Schema = ActiveContract[client].GetObjectiveSchema(obj_id);
+	if (!Schema.JumpToKey(CONTRACT_DEF_OBJ_EVENTS)) ThrowError("Contract \"%s\" doesn't have any events! Fix this, server developer!", ActiveContract[client].UUID);
 	if (!Schema.JumpToKey(event)) ThrowError("Contract \"%s\" doesn't have requested event \"%s\"", ActiveContract[client].UUID, event);
-	if (!Schema.JumpToKey("timer")) return;
+	if (!Schema.JumpToKey(CONTRACT_DEF_EVENT_TIMER)) return;
 	if (!Schema.JumpToKey(timer_event)) return;
 
 	char EventAction[64];
@@ -85,7 +85,7 @@ public void SendEventToTimer(int client, int obj_id, char event[MAX_EVENT_SIZE],
 	{
 		int Value = view_as<int>(Variable);
 		if (StrEqual(EventAction, "subtract_reward")) Value *= -1;
-		switch (view_as<ContractType>(ActiveContract[client].CachedSchema.GetNum("type")))
+		switch (view_as<ContractType>(ActiveContract[client].GetSchema().GetNum("type")))
 		{
 			case Contract_ObjectiveProgress: ModifyObjectiveProgress(client, Value, ActiveContract[client], obj_id);
 			case Contract_ContractProgress: ModifyContractProgress(client, Value, ActiveContract[client], obj_id);

--- a/addons/sourcemod/scripting/zcontracts/contracts_timers.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_timers.sp
@@ -6,31 +6,30 @@ public Action EventTimer(Handle hTimer, DataPack hPack)
 {
 	// Set to the beginning and unpack it.
 	hPack.Reset();
-	// Grab our client.
 	int client = hPack.ReadCell();
-	int iObjectiveID = hPack.ReadCell();
-	int iEventID = hPack.ReadCell();
+	int obj_id = hPack.ReadCell();
+	char event[MAX_EVENT_SIZE];
+	hPack.ReadString(event, sizeof(event));
+	float start = hPack.ReadFloat();
 
 	if (!IsClientValid(client)) return Plugin_Stop;
 	
-	Contract ClientContract;
-	GetClientContractStruct(client, ClientContract);
-	ContractObjective ActiveObjective;
-	ClientContract.m_hObjectives.GetArray(iObjectiveID, ActiveObjective);
-	ContractObjectiveEvent ObjectiveEvent;
-	ActiveObjective.m_hEvents.GetArray(iEventID, ObjectiveEvent, sizeof(ObjectiveEvent));
-	
 	// This is our actual time remaining for this loop. 
-	// Treat ObjectiveEvent.m_fTime like the inital starting time.
 	// This allows us to do stuff like add or subtract
 	// from the total time remaining.
 	static float TimeRemaining = 0.0;
 	if (g_TimerActive[client] == false)
 	{
-		TimeRemaining = ObjectiveEvent.m_fTime;
+		// Grab the starting time from the Schema.
+		KeyValues Schema = ActiveContract[client].CachedObjSchema.Get(obj_id);
+		if (!Schema.JumpToKey("events")) ThrowError("Contract \"%s\" doesn't have any events! Fix this, server developer!", ActiveContract[client].UUID);
+		if (!Schema.JumpToKey(event)) ThrowError("Contract \"%s\" doesn't have requested event \"%s\"", ActiveContract[client].UUID, event);
+		Schema.JumpToKey("timer");
+		
+		TimeRemaining = Schema.GetFloat("time");
 		if (g_DebugTimers.BoolValue)
 		{
-			LogMessage("[ZContracts] Timer started for %N: [OBJ: %d, EVENT: %d, TIME: %.1f]", client, iObjectiveID, iEventID, TimeRemaining);
+			LogMessage("[ZContracts] Timer started for %N: [OBJ: %d, EVENT: %s, TIME: %.1f]", client, obj_id, event, TimeRemaining);
 		}
 		g_TimerActive[client] = true;
 	}
@@ -45,81 +44,46 @@ public Action EventTimer(Handle hTimer, DataPack hPack)
 		g_TimeChange[client] = 0.0;
 	}
 
-	// Only progress forward if this loop is done!
-	if (GetGameTime() < ObjectiveEvent.m_fStarted + TimeRemaining) return Plugin_Continue;
-
-	ObjectiveEvent.m_iCurrentLoops++;
-	if (g_DebugTimers.BoolValue)
-	{
-		LogMessage("[ZContracts] Loop %d finished for timer started for %N: [OBJ: %d, EVENT: %d, MAX: %d]",
-		ObjectiveEvent.m_iCurrentLoops, client, iObjectiveID, iEventID, ObjectiveEvent.m_iMaxLoops);
-	}
-	
-	// Call an event for when this loop of the timer ends.
-	SendEventToTimer(client, iObjectiveID, iEventID, "OnLoopEnd");
-	
-	// Are we at the maximum of our loops?
-	if (ObjectiveEvent.m_iCurrentLoops >= ObjectiveEvent.m_iMaxLoops)
+	if (GetGameTime() < start + TimeRemaining) return Plugin_Continue;
+	else
 	{
 		// Call an event for when the timer ends.
 		SendEventToTimer(client, iObjectiveID, iEventID, "OnTimerEnd");
-
-		// Reset our variables.
-		ObjectiveEvent.m_fStarted = 0.0;
-		ObjectiveEvent.m_iCurrentLoops = 0;
-		ObjectiveEvent.m_iCurrentThreshold = 0;
-		ObjectiveEvent.m_hTimer = INVALID_HANDLE;
-		ActiveObjective.m_hEvents.SetArray(iEventID, ObjectiveEvent, sizeof(ContractObjectiveEvent));
+		ActiveContract[client].ObjectiveTimers.Set(obj_id, INVALID_HANDLE);
+		TimeRemaining = 0.0;
+		g_TimerActive[client] = false;
 
 		if (g_DebugTimers.BoolValue)
 		{
-			LogMessage("[ZContracts] Timer finished for %N: [OBJ: %d, EVENT: %d, REASON: Timer reached max loops]",
-			client, iObjectiveID, iEventID);
+			LogMessage("[ZContracts] Timer finished for %N: [OBJ: %d, EVENT: %s, REASON: Timer reached max loops]", client, obj_id, event);
 		}
-
-		TimeRemaining = 0.0;
-		g_TimerActive[client] = false;
 
 		// Exit out of the timer.
 		return Plugin_Stop;
 	}
 
-	// Restart this loop.
-	ObjectiveEvent.m_fStarted = GetGameTime();
-	TimeRemaining = ObjectiveEvent.m_fTime;
-
-	ActiveObjective.m_hEvents.SetArray(iEventID, ObjectiveEvent, sizeof(ContractObjectiveEvent));
-	ClientContract.m_hObjectives.SetArray(iObjectiveID, ActiveObjective);
 	return Plugin_Continue;
 }
 
-public void SendEventToTimer(int client, int objective, int event, const char[] timer_event)
+public void SendEventToTimer(int client, int objective, char event[MAX_EVENT_SIZE], const char[] timer_event)
 {
-	ContractObjective ActiveObjective;
-	ActiveContract[client].GetObjective(objective, ActiveObjective);
-	if (!ActiveObjective.m_bInitalized) return;
-	ContractObjectiveEvent ObjectiveEvent;
-	ActiveObjective.m_hEvents.GetArray(event, ObjectiveEvent, sizeof(ContractObjectiveEvent));
-	if (ObjectiveEvent.m_hTimer == INVALID_HANDLE) return;
-	KeyValues ObjSchema = GetObjectiveSchema(ActiveContract[client].m_sUUID, objective);
-	
-	// Jump down a bit.
-	ObjSchema.JumpToKey("events");
-	ObjSchema.JumpToKey(ObjectiveEvent.m_sEventName);
-	if (!ObjSchema.JumpToKey("timer")) return;
-	if (!ObjSchema.JumpToKey(timer_event)) return;
+	// Grab the starting time from the Schema.
+	KeyValues Schema = ActiveContract[client].CachedObjSchema.Get(obj_id);
+	if (!Schema.JumpToKey("events")) ThrowError("Contract \"%s\" doesn't have any events! Fix this, server developer!", Buffer.UUID);
+	if (!Schema.JumpToKey(event)) ThrowError("Contract \"%s\" doesn't have requested event \"%s\"", Buffer.UUID, event);
+	if (!Schema.JumpToKey("timer")) return;
+	if (!Schema.JumpToKey(timer_event)) return;
 
 	char EventAction[64];
-	ObjSchema.GetString("event", EventAction, sizeof(EventAction));
+	Schema.GetString("event", EventAction, sizeof(EventAction));
 	if (g_DebugTimers.BoolValue)
 	{
 		LogMessage("[ZContracts] Timer event fired for %N: [OBJ: %d, OBJ-EVENT: %d, EVENT: %s, ACTION: %s]",
 		client, objective, event, timer_event, EventAction);
 	}
-	float Variable = ObjSchema.GetFloat("variable");
+	float Variable = Schema.GetFloat("variable");
 
-	// What should we do here?
-	if (StrEqual(EventAction, "add_reward") || StrEqual(EventAction, "subtract_reward"))
+	if (StrContains(EventAction, "reward") != -1)
 	{
 		int Value = view_as<int>(Variable);
 		if (StrEqual(EventAction, "subtract_reward")) Value *= -1;
@@ -129,12 +93,13 @@ public void SendEventToTimer(int client, int objective, int event, const char[] 
 			case Contract_ContractProgress: ModifyContractProgress(client, Value, ActiveContract[client], objective);
 		}
 	}
-
-	if (StrEqual(EventAction, "add_loop")) ObjectiveEvent.m_iMaxLoops += view_as<int>(Variable);
-	if (StrEqual(EventAction, "subtract_loop")) ObjectiveEvent.m_iMaxLoops -= view_as<int>(Variable);
-
-	if (StrEqual(EventAction, "add_threshold")) ObjectiveEvent.m_iCurrentThreshold += view_as<int>(Variable);
-	if (StrEqual(EventAction, "subtract_threshold")) ObjectiveEvent.m_iCurrentThreshold -= view_as<int>(Variable);
+	if (StrContains(EventAction, "threshold") != -1)
+	{
+		int curr_threshold = ActiveContract[client].ObjectiveThreshold.Get(obj_id);
+		int Value = view_as<int>(Variable);
+		if (StrContains(EventAction, "subtract") != -1) Value *= -1;
+		ActiveContract[client].ObjectiveThreshold.Set(obj_id, curr_threshold + Value);
+	}
 
 	if (StrEqual(EventAction, "add_time")) g_TimeChange[client] = Variable;
 	if (StrEqual(EventAction, "subtract_time")) g_TimeChange[client] = Variable * -1.0;

--- a/addons/sourcemod/scripting/zcontracts/contracts_timers.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_timers.sp
@@ -50,6 +50,12 @@ public Action EventTimer(Handle hTimer, DataPack hPack)
 		// Call an event for when the timer ends.
 		SendEventToTimer(client, obj_id, event, "OnTimerEnd");
 		ActiveContract[client].ObjectiveTimers.Set(obj_id, INVALID_HANDLE);
+		ActiveContract[client].ObjectiveTimerStarted.Set(obj_id, -1.0);
+
+		StringMap ObjectiveThreshold = ActiveContract[client].ObjectiveThreshold.Get(obj_id);
+		ObjectiveThreshold.SetValue(event, 0);
+		ActiveContract[client].ObjectiveThreshold.Set(obj_id, ObjectiveThreshold);
+
 		TimeRemaining = 0.0;
 		g_TimerActive[client] = false;
 

--- a/addons/sourcemod/scripting/zcontracts/contracts_utils.sp
+++ b/addons/sourcemod/scripting/zcontracts/contracts_utils.sp
@@ -12,7 +12,7 @@ bool IsContractLockedForClient(int client, char UUID[MAX_UUID_SIZE])
 	if (g_ContractSchema.JumpToKey(UUID))
 	{
 		// Construct the required contracts.
-		if (g_ContractSchema.JumpToKey("required_contracts", false))
+		if (g_ContractSchema.JumpToKey(CONTRACT_DEF_REQUIRED, false))
 		{
 			int Value = 0;
 			for (;;)

--- a/addons/sourcemod/scripting/zcontracts_main.sp
+++ b/addons/sourcemod/scripting/zcontracts_main.sp
@@ -14,6 +14,7 @@
 
 Database g_DB = null;
 Handle g_DatabaseRetryTimer;
+KeyValues g_AdminDictList;
 
 Handle g_HudSync;
 
@@ -246,6 +247,21 @@ public void OnPluginStart()
 	RegConsoleCmd("sm_zcpref", OpenPrefPanelCmd);
 	RegConsoleCmd("sm_zchelp", OpenHelpPanelCmd);
 	RegConsoleCmd("sm_chelp", OpenHelpPanelCmd);
+
+	// ================ CONFIG ================
+	/*g_AdminDictList = new KeyValues("AdminDicts");
+	char FileDir[PLATFORM_MAX_PATH];
+	BuildPath(Path_SM, FileDir, sizeof(FileDir), "configs/zcontracts/");
+	NormalizePathToPOSIX(FileDir);
+	StrCat(FileDir, sizeof(FileDir), "admin_directories.txt");
+	if (!g_AdminDictList.ImportFromFile(FileDir))
+	{
+		LogMessage("Could not find \"%s\"!", FileDir);
+	}
+
+	char e[256];
+	g_AdminDictList.ExportToString(e, sizeof(e));
+	PrintToServer(e);*/
 }
 
 public void OnMapEnd()
@@ -903,6 +919,13 @@ public any Native_CanClientActivateContract(Handle plugin, int numParams)
 	if (g_DebugUnlockContracts.BoolValue) return true;
 
 	KeyValues Schema = GetContractSchema(UUID);
+
+	// Admin check.
+	/*char AdminFlags[64];
+	Schema.GetString(CONTRACT_DEF_REQUIRED_FLAG, AdminFlags, sizeof(AdminFlags));
+	PrintToChat(client, "flags: %s", AdminFlags);
+	int RequiredFlags = ReadFlagString(AdminFlags);
+	if (!StrEqual(AdminFlags, "") && !(RequiredFlags && GetUserFlagBits(client) & RequiredFlags)) return false;*/
 
 	// Time restriction check.
 	int BeginTimestampRestriction = Schema.GetNum(CONTRACT_DEF_UNIX_START, -1);

--- a/addons/sourcemod/scripting/zcontracts_tf2.sp
+++ b/addons/sourcemod/scripting/zcontracts_tf2.sp
@@ -151,7 +151,7 @@ public Action OnContractCompletableCheck(int client, char UUID[MAX_UUID_SIZE])
 {
 	KeyValues ContractSchema = GetContractSchema(UUID);
 	
-	if (ContractSchema.JumpToKey("classes"))
+	if (ContractSchema.JumpToKey(CONTRACT_DEF_TF2_CLASSES))
 	{
 		// Class check.
 		TFClassType Class = TF2_GetPlayerClass(client);


### PR DESCRIPTION
Things that have been done:
- Bumped `CONTRACKER_VERSION` to 3
- Ripped out a lot of code related to enum structs. `Contract` is the only thing that survives and it's been massively simplified
- Progress and thresholds are now stored in an `ArrayList`
- Ripped out 99% of the definitions from the enum structs. All of that data can now be grabbed from `KeyValues` using `GetSchema()` + `GetObjectiveSchema()`
- Standardized keys in contract definition files: `CONTRACT_DEF*` #define's in `zcontracts.inc`
- Removed loops from timers - pointless feature.
- Rewrote code that handles processing events
- Added a compile-time toggle for verbose debugging (`#define VERBOSE_DEBUG`)
- Removed `zc_database_update_time` and periodic DB saving. All saving will take place instantly when a Contract updates

Things that need to be done:
- Contracts can't be repeated
- Contracts can't be auto-repeated
- Timers don't work
- A lot more testing